### PR TITLE
fix `components add` by using custom ui.* registry

### DIFF
--- a/src/components/commands/add.ts
+++ b/src/components/commands/add.ts
@@ -14,17 +14,17 @@ export function createAddCommand(): Command {
           process.exit(1);
         }
 
-        console.log('Launching shadcn/ui CLI...');
-        console.log('Source: https://ui.elevenlabs.io\n');
+        const component = componentName || 'all';
+        const targetUrl = new URL(`/r/${component}.json`, 'https://ui.elevenlabs.io').toString();
 
-        // Prepare command arguments
-        const args = ['shadcn@latest', 'add'];
-        if (componentName) {
-          args.push(componentName);
-        }
+        console.log(`Installing ${component} from ElevenLabs UI registry...`);
+        console.log(`Source: ${targetUrl}\n`);
+
+        // Prepare command with custom registry URL
+        const fullCommand = `npx -y shadcn@latest add ${targetUrl}`;
 
         // Run shadcn add command interactively
-        const result = spawnSync('npx', args, {
+        const result = spawnSync(fullCommand, {
           stdio: 'inherit', // Allow interactive prompts
           shell: true
         });


### PR DESCRIPTION
Running `npx @elevenlabs/cli@latest components add orb` errored:

> ~/code/cli pennyroyalte…cn-repo-pull ❯ npx @elevenlabs/cli@latest components add orb
> Launching shadcn/ui CLI...
> Source: https://ui.elevenlabs.io
> 
> 
> 
> Something went wrong. Please check the error below for more details.
> If the problem persists, please open an issue on GitHub.
> 
> Message:
> The item at https://ui.shadcn.com/r/styles/new-york-v4/orb.json was not found. It may not exist at the registry.
> 
> Suggestion:
> Check if the item name is correct and the registry URL is accessible.

this was because default shadcn registry was used instead of custom one. This PR fixes it.