### PR TITLE
[fix] dynamic vars being broken in tests push (#45)

### DIFF
--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -133,7 +133,9 @@ export function toCamelCaseKeys<T = unknown>(value: T, skipHeaderConversion: boo
         result[k] = toCamelCaseKeys(v, false);
       } else {
         // Normal conversion
-        result[toCamelCaseKey(k)] = toCamelCaseKeys(v, k === 'request_headers' ? 'names-only' : false);
+        // Preserve keys for request_headers (HTTP header names) and dynamic_variables (user-defined variable names)
+        const preserveKeys = k === 'request_headers' || k === 'dynamic_variables';
+        result[toCamelCaseKey(k)] = toCamelCaseKeys(v, preserveKeys ? 'names-only' : false);
       }
     }
     return (result as unknown) as T;
@@ -156,7 +158,9 @@ export function toSnakeCaseKeys<T = unknown>(value: T, skipHeaderConversion: boo
         result[k] = toSnakeCaseKeys(v, false);
       } else {
         // Normal conversion
-        result[toSnakeCaseKey(k)] = toSnakeCaseKeys(v, k === 'request_headers' || k === 'requestHeaders' ? 'names-only' : false);
+        // Preserve keys for request_headers (HTTP header names) and dynamic_variables (user-defined variable names)
+        const preserveKeys = k === 'request_headers' || k === 'requestHeaders' || k === 'dynamic_variables' || k === 'dynamicVariables';
+        result[toSnakeCaseKey(k)] = toSnakeCaseKeys(v, preserveKeys ? 'names-only' : false);
       }
     }
     return (result as unknown) as T;


### PR DESCRIPTION
### Summary

  - Fix tests push command converting dynamic_variables keys
  to camelCase (#47)
  - User-defined variable names like damage_id, user_name were
   being converted to damageId, userName, breaking tests that
  reference these variables in prompts

  ### Changes

  - Add dynamic_variables/dynamicVariables to preserved key
  handling in toCamelCaseKeys and toSnakeCaseKeys (same
  pattern as request_headers)
  - Add tests for dynamic_variables key preservation and
  round-trip symmetry

  ### Test plan

  - New tests fail without fix, pass with fix
  - All 161 tests pass