### PR TITLE
fix: bump elevenlabs-js SDK to 2.36.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "format": "prettier --write src/**/*.ts"
   },
   "dependencies": {
-    "@elevenlabs/elevenlabs-js": "2.29.0",
+    "@elevenlabs/elevenlabs-js": "2.36.0",
     "@inkjs/ui": "^2.0.0",
     "@types/read": "^0.0.32",
     "chalk": "^5.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@elevenlabs/elevenlabs-js':
-        specifier: 2.29.0
-        version: 2.29.0
+        specifier: 2.36.0
+        version: 2.36.0
       '@inkjs/ui':
         specifier: ^2.0.0
         version: 2.0.0(ink@6.5.1(@types/react@19.2.1)(react@19.2.1))
@@ -271,8 +271,8 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@elevenlabs/elevenlabs-js@2.29.0':
-    resolution: {integrity: sha512-yxmWq7gBjNFzR5h88UmsShGeUqQBdjWVA3JYeFhy7ylMh6o4ws0ZUaJ0ydmrOTA96os7ez1q8IupvWHoVBnX2w==}
+  '@elevenlabs/elevenlabs-js@2.36.0':
+    resolution: {integrity: sha512-dnhJHmozQj2xBxgEbPa3clK1G3jY8xUmij8nzNHW9GBDYg2750OwgaSCnZmlFtm53MorEspmlcSu2+fzSeldkQ==}
     engines: {node: '>=18.0.0'}
 
   '@esbuild/android-arm64@0.18.20':
@@ -2463,7 +2463,7 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@elevenlabs/elevenlabs-js@2.29.0':
+  '@elevenlabs/elevenlabs-js@2.36.0':
     dependencies:
       command-exists: 1.2.9
       node-fetch: 2.7.0

--- a/src/shared/elevenlabs-api.ts
+++ b/src/shared/elevenlabs-api.ts
@@ -338,7 +338,7 @@ export async function getToolDependentAgentsApi(client: ElevenLabsClient, toolId
  * @param testConfig - The test configuration object
  * @returns Promise that resolves to the created test with ID
  */
-export async function createTestApi(client: ElevenLabsClient, testConfig: ElevenLabs.conversationalAi.CreateUnitTestRequest): Promise<{ id: string }> {
+export async function createTestApi(client: ElevenLabsClient, testConfig: ElevenLabs.conversationalAi.TestsCreateRequestBody): Promise<{ id: string }> {
   const response = await client.conversationalAi.tests.create(testConfig);
   return response as { id: string };
 }
@@ -375,7 +375,7 @@ export async function listTestsApi(client: ElevenLabsClient, pageSize: number = 
  * @param testConfig - The updated test configuration object
  * @returns Promise that resolves to the updated test object
  */
-export async function updateTestApi(client: ElevenLabsClient, testId: string, testConfig: ElevenLabs.conversationalAi.UpdateUnitTestRequest): Promise<unknown> {
+export async function updateTestApi(client: ElevenLabsClient, testId: string, testConfig: ElevenLabs.conversationalAi.TestsUpdateRequestBody): Promise<unknown> {
   const response = await client.conversationalAi.tests.update(testId, testConfig);
   return toSnakeCaseKeys(response);
 }

--- a/src/tests/__tests__/test-api.test.ts
+++ b/src/tests/__tests__/test-api.test.ts
@@ -63,7 +63,7 @@ describe("Test API Functions", () => {
 
       const result = await createTestApi(
         mockClient as unknown as ElevenLabsClient,
-        testConfig as ElevenLabs.conversationalAi.CreateUnitTestRequest
+        testConfig as ElevenLabs.conversationalAi.TestsCreateRequestBody
       );
 
       expect(mockClient.conversationalAi.tests.create).toHaveBeenCalledWith(
@@ -82,7 +82,7 @@ describe("Test API Functions", () => {
       await expect(
         createTestApi(
           mockClient as unknown as ElevenLabsClient,
-          testConfig as ElevenLabs.conversationalAi.CreateUnitTestRequest
+          testConfig as ElevenLabs.conversationalAi.TestsCreateRequestBody
         )
       ).rejects.toThrow("API Error");
     });
@@ -181,6 +181,7 @@ describe("Test API Functions", () => {
       mockClient.conversationalAi.tests.update.mockResolvedValue(mockResponse);
 
       const testConfig = {
+        type: "llm" as const,
         name: "Updated Test",
         chatHistory: [{ role: "user" as const, timeInCallSecs: 1 }],
         successCondition: "The agent responds appropriately",
@@ -392,6 +393,7 @@ describe("Test API Functions", () => {
       );
 
       const validTestConfig = {
+        type: "llm" as const,
         name: "Test",
         chatHistory: [{ role: "user" as const, timeInCallSecs: 1 }],
         successCondition: "Test condition",

--- a/src/tests/commands/impl.ts
+++ b/src/tests/commands/impl.ts
@@ -64,7 +64,7 @@ async function addTest(name: string, templateType: string = "basic-llm"): Promis
   const client = await getElevenLabsClient();
 
   try {
-    const testApiConfig = toCamelCaseKeys(testConfig) as unknown as ElevenLabs.conversationalAi.CreateUnitTestRequest;
+    const testApiConfig = toCamelCaseKeys(testConfig) as unknown as ElevenLabs.conversationalAi.TestsCreateRequestBody;
     const response = await createTestApi(client, testApiConfig);
     const testId = response.id;
 
@@ -163,7 +163,7 @@ async function pushTests(testId?: string, dryRun = false): Promise<void> {
 
     // Perform API operation
     try {
-      const testApiConfig = toCamelCaseKeys(testConfig) as unknown as ElevenLabs.conversationalAi.CreateUnitTestRequest;
+      const testApiConfig = toCamelCaseKeys(testConfig) as unknown as ElevenLabs.conversationalAi.TestsCreateRequestBody;
 
       if (!testId) {
         // Create new test
@@ -176,7 +176,7 @@ async function pushTests(testId?: string, dryRun = false): Promise<void> {
         changesMade = true;
       } else {
         // Update existing test
-        await updateTestApi(client, testId, testApiConfig as ElevenLabs.conversationalAi.UpdateUnitTestRequest);
+        await updateTestApi(client, testId, testApiConfig as ElevenLabs.conversationalAi.TestsUpdateRequestBody);
         console.log(`Updated test ${testDefName} (ID: ${testId})`);
       }
 


### PR DESCRIPTION
## Summary

- Bump `@elevenlabs/elevenlabs-js` from 2.29.0 to 2.36.0
- The new SDK treats `success_condition`, `success_examples`, and `failure_examples` as optional on test models, fixing deserialization errors for tool invocation tests
- Update renamed types: `CreateUnitTestRequest` -> `TestsCreateRequestBody`, `UpdateUnitTestRequest` -> `TestsUpdateRequestBody`

Fixes #58

## Test plan

- [x] `pnpm build` compiles
- [x] `pnpm test` -- all 161 tests pass
- [ ] Manual: `elevenlabs agents test <agent-id>` with tool invocation tests no longer errors
- [ ] Manual: `elevenlabs test pull` for tool invocation tests no longer errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)