### PR TITLE
fix: preserve language_presets locale code keys from case conversion

### DIFF
--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -594,6 +594,109 @@ describe("Utils", () => {
       });
     });
 
+    it("should preserve language_presets locale keys in toCamelCaseKeys", () => {
+      const input = {
+        conversation_config: {
+          language_presets: {
+            "pt-br": {
+              overrides: {
+                agent: {
+                  first_message: "Olá!"
+                }
+              }
+            },
+            "en": {
+              overrides: {
+                agent: {
+                  first_message: "Hello!"
+                }
+              }
+            }
+          }
+        }
+      };
+
+      const result = toCamelCaseKeys(input);
+
+      expect(result).toEqual({
+        conversationConfig: {
+          languagePresets: {
+            "pt-br": {              // preserved - locale code, NOT converted to "ptBr"
+              overrides: {
+                agent: {
+                  firstMessage: "Olá!"  // converted - schema field
+                }
+              }
+            },
+            "en": {                 // preserved - locale code
+              overrides: {
+                agent: {
+                  firstMessage: "Hello!" // converted - schema field
+                }
+              }
+            }
+          }
+        }
+      });
+    });
+
+    it("should preserve languagePresets locale keys in toSnakeCaseKeys", () => {
+      const input = {
+        conversationConfig: {
+          languagePresets: {
+            "pt-br": {
+              overrides: {
+                agent: {
+                  firstMessage: "Olá!"
+                }
+              }
+            }
+          }
+        }
+      };
+
+      const result = toSnakeCaseKeys(input);
+
+      expect(result).toEqual({
+        conversation_config: {
+          language_presets: {
+            "pt-br": {              // preserved - locale code, NOT converted to "pt_br"
+              overrides: {
+                agent: {
+                  first_message: "Olá!"  // converted - schema field
+                }
+              }
+            }
+          }
+        }
+      });
+    });
+
+    it("should maintain round-trip conversion symmetry for language_presets", () => {
+      const original = {
+        conversation_config: {
+          language_presets: {
+            "pt-br": {
+              overrides: {
+                agent: {
+                  first_message: "Olá!"
+                }
+              },
+              first_message_translation: {
+                source_hash: "test",
+                text: "Olá!"
+              }
+            }
+          }
+        }
+      };
+
+      const afterPush = toCamelCaseKeys(original);
+      const afterPull = toSnakeCaseKeys(afterPush);
+
+      expect(afterPull).toEqual(original);
+    });
+
     it("should preserve workflow nodes keys in toCamelCaseKeys", () => {
       const input = {
         workflow: {

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -123,6 +123,7 @@ function toSnakeCaseKey(key: string): string {
 const PRESERVE_CHILD_KEYS = new Set([
   'request_headers', 'requestHeaders',
   'dynamic_variables', 'dynamicVariables',
+  'language_presets', 'languagePresets',
   'nodes',
   'edges',
 ]);


### PR DESCRIPTION
Problem: Ran into an issue where I was running `elevenlabs agents pull`, making some changes, and then running `elevenlabs agents push`. Because I had brazilian portuguese in the language presets, the initial pull looked like

```
        "language_presets": {
            "pt_br": {
                "overrides": {
                    "agent": {
                        "first_message": "Olá! Estou aqui para ajudá-lo a encontrar a ferramenta de software certa. O que você está tentando resolver?"
                    }
                },
                "first_message_translation": {
                    "source_hash": "{\"firstMessage\":\"Hi there! I'm here to help you find the right software tool. What are you solving for? \",\"language\":\"en\"}",
                    "text": "Olá! Estou aqui para ajudá-lo a encontrar a ferramenta de software certa. O que você está tentando resolver?"
                }
            },
```

And then on the push ran into an issue because `pt_br` became `ptBr` and I got this error from the api:
```
  "Value error, Preset languages must be one of en, zh, es, hi, pt, fr, de, ja, ar, ko,
  id, it, nl, tr, pl, ru, sv, tl, fil, ms, ro, uk, el, cs, da, fi, bg, hr, sk, ta, vi,
  no, hu, af, hy, as, az, be, bn, bs, ca, et, gl, ka, gu, ha, he, is, ga, jv, kn, kk,
  ky, lv, lt, lb, mk, ml, mr, ne, ps, fa, pa, sr, sd, sl, so, sw, te, th, ur, cy, pt-br
  but got ptBr"
  ```

I made this change on a local fork and it worked so wanted to contribute upstream.

