### PR TITLE
fix: preserve model_usage keys from case conversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elevenlabs/cli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "CLI tool to manage ElevenLabs agents",
   "type": "module",
   "keywords": [

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -824,6 +824,90 @@ describe("Utils", () => {
       expect(afterPull).toEqual(originalWorkflow);
     });
 
+    it("should preserve model_usage keys in toCamelCaseKeys", () => {
+      const input = {
+        from_conversation_metadata: {
+          original_agent_reply: {
+            llm_usage: {
+              model_usage: {
+                "gpt_5.2": { input_tokens: 100, output_tokens: 50 },
+                "gpt-4o-mini": { input_tokens: 200, output_tokens: 100 },
+                "gemini-2.5-flash": { input_tokens: 300, output_tokens: 150 },
+                "claude-3-opus": { input_tokens: 400, output_tokens: 200 }
+              }
+            }
+          }
+        }
+      };
+
+      const result = toCamelCaseKeys(input);
+
+      expect(result).toEqual({
+        fromConversationMetadata: {
+          originalAgentReply: {
+            llmUsage: {
+              modelUsage: {
+                "gpt_5.2": { inputTokens: 100, outputTokens: 50 },          // preserved - model name
+                "gpt-4o-mini": { inputTokens: 200, outputTokens: 100 },      // preserved - model name
+                "gemini-2.5-flash": { inputTokens: 300, outputTokens: 150 }, // preserved - model name
+                "claude-3-opus": { inputTokens: 400, outputTokens: 200 }     // preserved - model name
+              }
+            }
+          }
+        }
+      });
+    });
+
+    it("should preserve modelUsage keys in toSnakeCaseKeys", () => {
+      const input = {
+        fromConversationMetadata: {
+          originalAgentReply: {
+            llmUsage: {
+              modelUsage: {
+                "gpt-5.2": { inputTokens: 100, outputTokens: 50 },
+                "gpt-4o-mini": { inputTokens: 200, outputTokens: 100 }
+              }
+            }
+          }
+        }
+      };
+
+      const result = toSnakeCaseKeys(input);
+
+      expect(result).toEqual({
+        from_conversation_metadata: {
+          original_agent_reply: {
+            llm_usage: {
+              model_usage: {
+                "gpt-5.2": { input_tokens: 100, output_tokens: 50 },   // preserved - model name
+                "gpt-4o-mini": { input_tokens: 200, output_tokens: 100 } // preserved - model name
+              }
+            }
+          }
+        }
+      });
+    });
+
+    it("should maintain round-trip conversion symmetry for model_usage", () => {
+      const original = {
+        from_conversation_metadata: {
+          original_agent_reply: {
+            llm_usage: {
+              model_usage: {
+                "gpt_5.2": { input_tokens: 100, output_tokens: 50 },
+                "gpt-4o-mini": { input_tokens: 200, output_tokens: 100 }
+              }
+            }
+          }
+        }
+      };
+
+      const afterPush = toCamelCaseKeys(original);
+      const afterPull = toSnakeCaseKeys(afterPush);
+
+      expect(afterPull).toEqual(original);
+    });
+
     it("should maintain round-trip conversion symmetry for dynamic_variables", () => {
       // Simulate pull → push cycle for tests
       const originalTestConfig = {

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -124,6 +124,7 @@ const PRESERVE_CHILD_KEYS = new Set([
   'request_headers', 'requestHeaders',
   'dynamic_variables', 'dynamicVariables',
   'language_presets', 'languagePresets',
+  'model_usage', 'modelUsage',
   'nodes',
   'edges',
 ]);


### PR DESCRIPTION
## Summary
- Model name keys under `model_usage` (e.g. `gpt_5.2`, `gpt-4o-mini`, `gemini-2.5-flash`) are user-defined identifiers, not schema fields
- The case conversion logic was mangling them during test push (`gpt_5.2` -> `gpt5.2`, `gpt-4o-mini` -> `gpt4oMini`), causing 422 validation errors
- Added `model_usage` / `modelUsage` to `PRESERVE_CHILD_KEYS` in `src/shared/utils.ts`, following the same pattern used for `language_presets`, `dynamic_variables`, `nodes`, and `edges`

## Test plan
- [x] Added unit test: preserve model_usage keys in toCamelCaseKeys
- [x] Added unit test: preserve modelUsage keys in toSnakeCaseKeys
- [x] Added unit test: round-trip conversion symmetry for model_usage
- [x] All 46 utils tests pass
- [x] Manual test: `elevenlabs tests push` with config containing `model_usage` keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)