### PR TITLE
fix: update pnpm-lock.yaml to match elevenlabs-js ^2.41.1 specifier

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@elevenlabs/elevenlabs-js':
-        specifier: 2.36.0
-        version: 2.36.0
+        specifier: ^2.41.1
+        version: 2.41.1
       '@inkjs/ui':
         specifier: ^2.0.0
         version: 2.0.0(ink@6.5.1(@types/react@19.2.1)(react@19.2.1))
@@ -271,8 +271,8 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@elevenlabs/elevenlabs-js@2.36.0':
-    resolution: {integrity: sha512-dnhJHmozQj2xBxgEbPa3clK1G3jY8xUmij8nzNHW9GBDYg2750OwgaSCnZmlFtm53MorEspmlcSu2+fzSeldkQ==}
+  '@elevenlabs/elevenlabs-js@2.41.1':
+    resolution: {integrity: sha512-rYpQq49avDjpTtgeOI2sYoMmjyj01egCaPx/bzxemtX8TP1AXOJt3jLYAydOcTz/SBQDBWIOIoNW1tozLROUoA==}
     engines: {node: '>=18.0.0'}
 
   '@esbuild/android-arm64@0.18.20':
@@ -2463,7 +2463,7 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@elevenlabs/elevenlabs-js@2.36.0':
+  '@elevenlabs/elevenlabs-js@2.41.1':
     dependencies:
       command-exists: 1.2.9
       node-fetch: 2.7.0


### PR DESCRIPTION
The lock file was not updated in #71, causing frozen-lockfile installs to fail with ERR_PNPM_OUTDATED_LOCKFILE.