### PR TITLE
fix: preserve data_collection child keys from case conversion (#70)

### DIFF
--- a/src/__tests__/casing.test.ts
+++ b/src/__tests__/casing.test.ts
@@ -299,6 +299,102 @@ describe("Key casing normalization", () => {
     });
   });
 
+  it("createAgentApi preserves data_collection child keys (user-defined identifiers)", async () => {
+    const client = makeMockClient();
+    const conversation_config = {
+      agent: { prompt: { prompt: "hi", temperature: 0 } },
+    } as unknown as Record<string, unknown>;
+    const platform_settings = {
+      data_collection: {
+        need_callback: { type: "boolean", description: "Whether to call back" },
+        call_end_reason: { type: "string", description: "Why the call ended" },
+        human_reached: { type: "boolean", description: "Was a human reached" },
+      },
+    } as unknown as Record<string, unknown>;
+
+    await createAgentApi(
+      client,
+      "Agent with data_collection",
+      conversation_config,
+      platform_settings,
+      undefined,
+      []
+    );
+
+    const payload = (client.conversationalAi.agents.create as jest.Mock).mock.calls[0][0];
+
+    // data_collection top-level key is camelized to dataCollection (envelope convention)
+    expect(payload.platformSettings).toHaveProperty("dataCollection");
+    // Children are user-defined identifiers — must be preserved as-is (snake_case stays snake_case)
+    expect(payload.platformSettings.dataCollection).toHaveProperty("need_callback");
+    expect(payload.platformSettings.dataCollection).toHaveProperty("call_end_reason");
+    expect(payload.platformSettings.dataCollection).toHaveProperty("human_reached");
+    // Leaf values under each identifier — nested schema fields like 'type'/'description' stay as-is (no underscores to convert)
+    expect(payload.platformSettings.dataCollection.need_callback).toEqual({
+      type: "boolean",
+      description: "Whether to call back",
+    });
+  });
+
+  it("updateAgentApi preserves data_collection child keys (user-defined identifiers)", async () => {
+    const client = makeMockClient();
+    const conversation_config = {
+      agent: { prompt: { prompt: "updated", temperature: 0 } },
+    } as unknown as Record<string, unknown>;
+    const platform_settings = {
+      data_collection: {
+        need_callback: { type: "boolean", description: "Callback requested" },
+      },
+    } as unknown as Record<string, unknown>;
+
+    await updateAgentApi(
+      client,
+      "agent_123",
+      "Updated",
+      conversation_config,
+      platform_settings,
+      undefined,
+      []
+    );
+
+    const [, payload] = (client.conversationalAi.agents.update as jest.Mock).mock.calls[0];
+
+    expect(payload.platformSettings).toHaveProperty("dataCollection");
+    expect(payload.platformSettings.dataCollection).toHaveProperty("need_callback");
+  });
+
+  it("getAgentApi preserves data_collection child keys on inbound snake_case conversion", async () => {
+    const getWithDataCollection = jest.fn().mockResolvedValue({
+      agentId: "agent_123",
+      name: "Test",
+      conversationConfig: {
+        agent: { prompt: { prompt: "hi", temperature: 0 } },
+      },
+      platformSettings: {
+        dataCollection: {
+          need_callback: { type: "boolean", description: "Callback" },
+          call_end_reason: { type: "string" },
+        },
+      },
+      tags: [],
+    });
+    const client = {
+      conversationalAi: { agents: { get: getWithDataCollection } },
+    } as unknown as ElevenLabsClient;
+
+    const response = await getAgentApi(client, "agent_123") as Record<string, any>;
+
+    // Envelope snake_cases back for disk
+    expect(response.platform_settings).toHaveProperty("data_collection");
+    // User-defined identifiers preserved as-is — no round-trip corruption
+    expect(response.platform_settings.data_collection).toHaveProperty("need_callback");
+    expect(response.platform_settings.data_collection).toHaveProperty("call_end_reason");
+    expect(response.platform_settings.data_collection.need_callback).toEqual({
+      type: "boolean",
+      description: "Callback",
+    });
+  });
+
   it("createAgentApi preserves 'tools' field when 'tool_ids' is not present", async () => {
     const client = makeMockClient();
     const conversation_config = {

--- a/src/__tests__/casing.test.ts
+++ b/src/__tests__/casing.test.ts
@@ -373,7 +373,7 @@ describe("Key casing normalization", () => {
       platformSettings: {
         dataCollection: {
           need_callback: { type: "boolean", description: "Callback" },
-          call_end_reason: { type: "string" },
+          callEndReason: { type: "string" },
         },
       },
       tags: [],
@@ -388,7 +388,9 @@ describe("Key casing normalization", () => {
     expect(response.platform_settings).toHaveProperty("data_collection");
     // User-defined identifiers preserved as-is — no round-trip corruption
     expect(response.platform_settings.data_collection).toHaveProperty("need_callback");
-    expect(response.platform_settings.data_collection).toHaveProperty("call_end_reason");
+    // camelCase child key must also be preserved (not converted to call_end_reason)
+    expect(response.platform_settings.data_collection).toHaveProperty("callEndReason");
+    expect(response.platform_settings.data_collection).not.toHaveProperty("call_end_reason");
     expect(response.platform_settings.data_collection.need_callback).toEqual({
       type: "boolean",
       description: "Callback",

--- a/src/__tests__/casing.test.ts
+++ b/src/__tests__/casing.test.ts
@@ -373,7 +373,7 @@ describe("Key casing normalization", () => {
       platformSettings: {
         dataCollection: {
           need_callback: { type: "boolean", description: "Callback" },
-          callEndReason: { type: "string" },
+          call_end_reason: { type: "string" },
         },
       },
       tags: [],
@@ -388,13 +388,36 @@ describe("Key casing normalization", () => {
     expect(response.platform_settings).toHaveProperty("data_collection");
     // User-defined identifiers preserved as-is — no round-trip corruption
     expect(response.platform_settings.data_collection).toHaveProperty("need_callback");
-    // camelCase child key must also be preserved (not converted to call_end_reason)
-    expect(response.platform_settings.data_collection).toHaveProperty("callEndReason");
-    expect(response.platform_settings.data_collection).not.toHaveProperty("call_end_reason");
+    expect(response.platform_settings.data_collection).toHaveProperty("call_end_reason");
     expect(response.platform_settings.data_collection.need_callback).toEqual({
       type: "boolean",
       description: "Callback",
     });
+  });
+
+  it("getAgentApi does not snake_case camelCase data_collection child keys", async () => {
+    const getWithDataCollection = jest.fn().mockResolvedValue({
+      agentId: "agent_123",
+      name: "Test",
+      conversationConfig: {
+        agent: { prompt: { prompt: "hi", temperature: 0 } },
+      },
+      platformSettings: {
+        dataCollection: {
+          callEndReason: { type: "string", description: "Why the call ended" },
+        },
+      },
+      tags: [],
+    });
+    const client = {
+      conversationalAi: { agents: { get: getWithDataCollection } },
+    } as unknown as ElevenLabsClient;
+
+    const response = await getAgentApi(client, "agent_123") as Record<string, any>;
+
+    expect(response.platform_settings).toHaveProperty("data_collection");
+    expect(response.platform_settings.data_collection).toHaveProperty("callEndReason");
+    expect(response.platform_settings.data_collection).not.toHaveProperty("call_end_reason");
   });
 
   it("createAgentApi preserves 'tools' field when 'tool_ids' is not present", async () => {

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -125,6 +125,7 @@ const PRESERVE_CHILD_KEYS = new Set([
   'dynamic_variables', 'dynamicVariables',
   'language_presets', 'languagePresets',
   'model_usage', 'modelUsage',
+  'data_collection', 'dataCollection',
   'nodes',
   'edges',
 ]);


### PR DESCRIPTION
## Summary

Adds `data_collection` / `dataCollection` to `PRESERVE_CHILD_KEYS` so its immediate children (user-defined identifiers like `need_callback`, `call_end_reason`, `human_reached`) are not silently rewritten to camelCase by `toCamelCaseKeys` on push or to snake_case by `toSnakeCaseKeys` on pull.

Closes #70.

## Why

`data_collection` is the same class of construct as `dynamic_variables`, `language_presets`, `model_usage`, `nodes`, `edges` — its immediate children are **user-defined identifiers** that the platform stores verbatim. Case conversion is corrupting. In particular, the dashboard's callback-checkbox feature keys on the literal `need_callback` identifier; after a CLI push those show up on the platform as `needCallback` and the feature silently stops working.

Fix follows the same one-line pattern as the prior `model_usage` fix (#72) and `language_presets` fix (#65).

## Test plan

Three new cases in `src/__tests__/casing.test.ts`:

- `createAgentApi preserves data_collection child keys (user-defined identifiers)` — verifies `platformSettings.dataCollection.need_callback` (and siblings) survive outbound conversion with their exact original keys.
- `updateAgentApi preserves data_collection child keys (user-defined identifiers)` — same assertion on the update path.
- `getAgentApi preserves data_collection child keys on inbound snake_case conversion` — verifies the round-trip back to disk keeps children intact.

Reproduced the bug locally by running the new tests against `main` (2 of 3 fail: push-direction tests rewrite children to camelCase). With the fix, all 11 `casing.test.ts` cases pass.

No regressions: the pre-existing failures in `tools.test.ts`, `add-commands-filename.integration.test.ts`, and `test-commands.integration.test.ts` reproduce identically on `main` without this patch, so they are unrelated to this change.