### PR TITLE
fix: paginate listTestsApi to return every test (#75)

### DIFF
--- a/src/shared/elevenlabs-api.ts
+++ b/src/shared/elevenlabs-api.ts
@@ -417,15 +417,33 @@ export async function getTestApi(client: ElevenLabsClient, testId: string): Prom
 }
 
 /**
- * Lists all tests from the ElevenLabs API.
+ * Lists all tests from the ElevenLabs API, paginating through every page.
+ *
+ * The underlying SDK endpoint returns at most `pageSize` entries per call (cap 100).
+ * This helper loops using the response cursor until `hasMore` is false, so callers
+ * always receive the complete set regardless of how many tests exist.
  *
  * @param client - An initialized ElevenLabs client
- * @param pageSize - Maximum number of tests to return per page (default: 30)
- * @returns Promise that resolves to a list of test objects
+ * @param pageSize - Page size for each API call (default: 100, SDK max)
+ * @returns Promise that resolves to every test in the workspace
  */
-export async function listTestsApi(client: ElevenLabsClient, pageSize: number = 30): Promise<unknown[]> {
-  const response = await client.conversationalAi.tests.list({ pageSize });
-  return (response).tests || [];
+export async function listTestsApi(client: ElevenLabsClient, pageSize: number = 100): Promise<unknown[]> {
+  const allTests: unknown[] = [];
+  let cursor: string | undefined;
+  do {
+    const request: { pageSize: number; cursor?: string } = { pageSize };
+    if (cursor) request.cursor = cursor;
+    const response = await client.conversationalAi.tests.list(request) as {
+      tests?: unknown[];
+      nextCursor?: string;
+      hasMore?: boolean;
+    };
+    if (response.tests?.length) allTests.push(...response.tests);
+    if (!response.hasMore) break;
+    cursor = response.nextCursor;
+    if (!cursor) break;
+  } while (true);
+  return allTests;
 }
 
 /**

--- a/src/tests/__tests__/test-api.test.ts
+++ b/src/tests/__tests__/test-api.test.ts
@@ -133,6 +133,7 @@ describe("Test API Functions", () => {
           { id: "test_1", name: "Test 1" },
           { id: "test_2", name: "Test 2" },
         ],
+        hasMore: false,
       };
 
       mockClient.conversationalAi.tests.list.mockResolvedValue(mockResponse);
@@ -142,13 +143,13 @@ describe("Test API Functions", () => {
       );
 
       expect(mockClient.conversationalAi.tests.list).toHaveBeenCalledWith({
-        pageSize: 30,
+        pageSize: 100,
       });
       expect(result).toEqual(mockResponse.tests);
     });
 
     it("should list tests with custom page size", async () => {
-      const mockResponse = { tests: [] };
+      const mockResponse = { tests: [], hasMore: false };
       mockClient.conversationalAi.tests.list.mockResolvedValue(mockResponse);
 
       await listTestsApi(mockClient as unknown as ElevenLabsClient, 50);
@@ -167,6 +168,74 @@ describe("Test API Functions", () => {
       );
 
       expect(result).toEqual([]);
+    });
+
+    it("should paginate through every page until hasMore is false (fixes #75)", async () => {
+      const page1 = {
+        tests: [{ id: "test_1" }, { id: "test_2" }],
+        nextCursor: "cursor_abc",
+        hasMore: true,
+      };
+      const page2 = {
+        tests: [{ id: "test_3" }, { id: "test_4" }],
+        nextCursor: "cursor_def",
+        hasMore: true,
+      };
+      const page3 = {
+        tests: [{ id: "test_5" }],
+        hasMore: false,
+      };
+
+      mockClient.conversationalAi.tests.list
+        .mockResolvedValueOnce(page1)
+        .mockResolvedValueOnce(page2)
+        .mockResolvedValueOnce(page3);
+
+      const result = await listTestsApi(
+        mockClient as unknown as ElevenLabsClient
+      );
+
+      expect(mockClient.conversationalAi.tests.list).toHaveBeenCalledTimes(3);
+      // First call: no cursor
+      expect(mockClient.conversationalAi.tests.list).toHaveBeenNthCalledWith(1, {
+        pageSize: 100,
+      });
+      // Second call: cursor from page1
+      expect(mockClient.conversationalAi.tests.list).toHaveBeenNthCalledWith(2, {
+        pageSize: 100,
+        cursor: "cursor_abc",
+      });
+      // Third call: cursor from page2
+      expect(mockClient.conversationalAi.tests.list).toHaveBeenNthCalledWith(3, {
+        pageSize: 100,
+        cursor: "cursor_def",
+      });
+      // All 5 tests collected across 3 pages
+      expect(result).toEqual([
+        { id: "test_1" },
+        { id: "test_2" },
+        { id: "test_3" },
+        { id: "test_4" },
+        { id: "test_5" },
+      ]);
+    });
+
+    it("should stop pagination when hasMore=true but nextCursor is missing (defensive)", async () => {
+      const page1 = {
+        tests: [{ id: "test_1" }],
+        hasMore: true,
+        // nextCursor intentionally omitted — malformed response, don't loop forever
+      };
+
+      mockClient.conversationalAi.tests.list.mockResolvedValue(page1);
+
+      const result = await listTestsApi(
+        mockClient as unknown as ElevenLabsClient
+      );
+
+      // Should have stopped after first page rather than looping
+      expect(mockClient.conversationalAi.tests.list).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([{ id: "test_1" }]);
     });
   });
 

--- a/src/tests/commands/impl.ts
+++ b/src/tests/commands/impl.ts
@@ -232,9 +232,9 @@ async function pullTestsFromEnvironment(options: { test?: string; outputDir: str
       throw new Error(`Failed to fetch test with ID '${options.test}': ${error}`);
     }
   } else {
-    // Fetch all tests from ElevenLabs
+    // Fetch all tests from ElevenLabs (paginates internally until hasMore is false)
     console.log('Fetching all tests from ElevenLabs...');
-    testsList = await listTestsApi(client, 30);
+    testsList = await listTestsApi(client);
 
     if (testsList.length === 0) {
       console.log('No tests found in your ElevenLabs workspace.');


### PR DESCRIPTION
## Summary

`listTestsApi` previously issued a single `tests.list` call with a hardcoded `page_size: 30`, so any workspace with more than 30 tests silently lost the remainder. `tests pull` and `tests pull --all` only ever saw the first page.

The SDK's `GetTestsPageResponseModel` already exposes `nextCursor` and `hasMore`. This PR loops using the cursor until `hasMore` is false, so every test is returned regardless of how many exist. Default `pageSize` bumped from 30 to 100 (the SDK's documented maximum) to cut round-trips.

Closes #75.

## Defensive behaviour

If the API ever returns `hasMore: true` without a `nextCursor`, the loop exits after that page rather than spinning forever. Added as a test case.

## Call-site simplification

`src/tests/commands/impl.ts` previously passed a literal `30` — it now calls `listTestsApi(client)` and inherits the new, correct default.

## Test plan

Two new cases in `src/tests/__tests__/test-api.test.ts`:

- `should paginate through every page until hasMore is false (fixes #75)` — mocks three pages, asserts all three `.list` calls are made with the correct cursor each time, and that all five tests are returned in order.
- `should stop pagination when hasMore=true but nextCursor is missing (defensive)` — verifies the infinite-loop guard.

Updated two existing cases to include `hasMore: false` in their mock responses and to expect the new default `pageSize: 100`. All 20 `test-api.test.ts` cases pass. No regressions elsewhere — the 20 failing tests in `tools.test.ts`, `add-commands-filename.integration.test.ts`, and `test-commands.integration.test.ts` reproduce identically on `main` without this patch, so they are unrelated to this change.