### PR TITLE
fix: resolve no-constant-condition lint error in listTestsApi

### DIFF
--- a/src/shared/elevenlabs-api.ts
+++ b/src/shared/elevenlabs-api.ts
@@ -430,7 +430,7 @@ export async function getTestApi(client: ElevenLabsClient, testId: string): Prom
 export async function listTestsApi(client: ElevenLabsClient, pageSize: number = 100): Promise<unknown[]> {
   const allTests: unknown[] = [];
   let cursor: string | undefined;
-  do {
+  while (true) {
     const request: { pageSize: number; cursor?: string } = { pageSize };
     if (cursor) request.cursor = cursor;
     const response = await client.conversationalAi.tests.list(request) as {
@@ -442,7 +442,7 @@ export async function listTestsApi(client: ElevenLabsClient, pageSize: number = 
     if (!response.hasMore) break;
     cursor = response.nextCursor;
     if (!cursor) break;
-  } while (true);
+  }
   return allTests;
 }
 


### PR DESCRIPTION
## Summary

- Change `do { } while (true)` to `while (true)` in `listTestsApi`
- ESLint v9's `no-constant-condition` rule defaults to `checkLoops: "allExceptWhileTrue"`, which allows `while (true)` but flags `do { } while (true)`
- Matches the existing `listAgentsApi` pattern

## Test plan

- [x] `pnpm run lint` passes (0 errors)
- [x] All 20 `test-api.test.ts` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)