### PR TITLE
Fix npx availability check on Windows

### DIFF
--- a/src/components/__tests__/add-command.test.ts
+++ b/src/components/__tests__/add-command.test.ts
@@ -1,0 +1,48 @@
+import { spawnSync } from "child_process";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import { createAddCommand } from "../commands/add";
+
+jest.mock("child_process", () => ({
+  spawnSync: jest.fn(),
+}));
+
+describe("components add command", () => {
+  const mockedSpawnSync = spawnSync as unknown as jest.Mock;
+  let logSpy: jest.SpiedFunction<typeof console.log>;
+
+  beforeEach(() => {
+    mockedSpawnSync.mockReset();
+    mockedSpawnSync.mockReturnValue({ status: 0 });
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it("checks npx availability through the shell for Windows command resolution", async () => {
+    const command = createAddCommand();
+
+    await command.parseAsync(["bar-visualizer"], { from: "user" });
+
+    expect(mockedSpawnSync).toHaveBeenNthCalledWith(1, "npx", ["--version"], {
+      encoding: "utf-8",
+      shell: true,
+    });
+    expect(mockedSpawnSync).toHaveBeenNthCalledWith(
+      2,
+      "npx -y shadcn@latest add https://ui.elevenlabs.io/r/bar-visualizer.json",
+      {
+        stdio: "inherit",
+        shell: true,
+      }
+    );
+  });
+});

--- a/src/components/commands/add.ts
+++ b/src/components/commands/add.ts
@@ -8,8 +8,8 @@ export function createAddCommand(): Command {
     .argument('[name]', 'Name of the component to add (optional)')
     .action(async (componentName?: string) => {
       try {
-        // Check if npx is available
-        const npxCheck = spawnSync('npx', ['--version'], { encoding: 'utf-8' });
+        // Check if npx is available. shell:true lets Windows resolve npx.cmd/npx.ps1.
+        const npxCheck = spawnSync('npx', ['--version'], { encoding: 'utf-8', shell: true });
         if (npxCheck.error) {
           console.error('Error: npx is not available. Please install Node.js/npm.');
           process.exit(1);


### PR DESCRIPTION
This fixes #77 

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Run the components add `npx --version` availability check through the shell so Windows can resolve `npx.cmd`/`npx.ps1`
- Add coverage for the components add command spawn options

## Verification
- `npm test -- --runTestsByPath src/components/__tests__/add-command.test.ts`
- `npm run build`
- `npm test`
- `npm run lint` (passes with existing warnings in `src/__tests__/branches.test.ts` and `src/__tests__/casing.test.ts`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c020af8f-3cdf-483f-b3be-a34a79d1828e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c020af8f-3cdf-483f-b3be-a34a79d1828e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

