### PR TITLE
Fix agent push for unsupported workflow nodes

### DIFF
--- a/src/__tests__/workflow.test.ts
+++ b/src/__tests__/workflow.test.ts
@@ -60,6 +60,36 @@ describe("Workflow support in agents", () => {
     } as unknown as ElevenLabsClient;
   }
 
+  function makeRawWorkflowClient(responseBody: Record<string, unknown> = { agent_id: "agent_say_123" }) {
+    const create = jest.fn().mockRejectedValue(new Error("SDK create should not be called for unsupported workflow nodes"));
+    const update = jest.fn().mockRejectedValue(new Error("SDK update should not be called for unsupported workflow nodes"));
+    const get = jest.fn();
+    const fetcher = jest.fn().mockResolvedValue({
+      ok: true,
+      body: responseBody,
+      rawResponse: {}
+    });
+
+    return {
+      client: {
+        _options: {
+          apiKey: "test-api-key",
+          baseUrl: "https://api.test",
+          headers: {
+            "X-Source": "agents-cli"
+          },
+          fetcher
+        },
+        conversationalAi: {
+          agents: { create, update, get },
+        },
+      } as unknown as ElevenLabsClient,
+      create,
+      update,
+      fetcher
+    };
+  }
+
   describe("createAgentApi", () => {
     it("should send workflow when provided", async () => {
       const client = makeMockClient();
@@ -136,6 +166,69 @@ describe("Workflow support in agents", () => {
         expect.objectContaining({
           name: "Agent without Workflow",
           workflow: undefined,
+        })
+      );
+    });
+
+    it("should bypass SDK workflow validation for Say nodes", async () => {
+      const { client, create, fetcher } = makeRawWorkflowClient();
+      const conversation_config = {
+        conversation: {
+          client_events: ["audio"],
+        },
+        agent: { prompt: { prompt: "hi", temperature: 0 } },
+      } as unknown as Record<string, unknown>;
+
+      const workflow = {
+        nodes: {
+          "start": { type: "start", position: { x: 0, y: 0 } },
+          "say_1": {
+            type: "say",
+            position: { x: 50, y: 50 },
+            config: { text: "Welcome" }
+          },
+          "end": { type: "end", position: { x: 100, y: 100 } }
+        },
+        edges: {
+          "edge_start_to_say": { from: "start", to: "say_1" },
+          "edge_say_to_end": { from: "say_1", to: "end" }
+        }
+      };
+
+      const agentId = await createAgentApi(
+        client,
+        "Agent with Say Workflow",
+        conversation_config,
+        undefined,
+        workflow,
+        ["workflow"]
+      );
+
+      expect(agentId).toBe("agent_say_123");
+      expect(create).not.toHaveBeenCalled();
+      expect(fetcher).toHaveBeenCalledTimes(1);
+      expect(fetcher).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://api.test/v1/convai/agents/create",
+          method: "POST",
+          requestType: "json",
+          body: expect.objectContaining({
+            name: "Agent with Say Workflow",
+            conversation_config: expect.any(Object),
+            workflow: expect.objectContaining({
+              nodes: expect.objectContaining({
+                say_1: expect.objectContaining({
+                  type: "say",
+                  config: { text: "Welcome" }
+                })
+              }),
+              edges: expect.objectContaining({
+                edge_start_to_say: expect.any(Object),
+                edge_say_to_end: expect.any(Object)
+              })
+            }),
+            tags: ["workflow"]
+          })
         })
       );
     });
@@ -217,6 +310,71 @@ describe("Workflow support in agents", () => {
       expect(payload).toEqual(
         expect.objectContaining({
           workflow: undefined,
+        })
+      );
+    });
+
+    it("should bypass SDK workflow validation when updating Say nodes", async () => {
+      const { client, update, fetcher } = makeRawWorkflowClient({
+        agent_id: "agent_workflow_123",
+        version_id: "version_123",
+        branch_id: "branch_123"
+      });
+      const conversation_config = {
+        conversation: {
+          client_events: ["audio"],
+        },
+      } as unknown as Record<string, unknown>;
+
+      const workflow = {
+        nodes: {
+          "say_1": {
+            type: "say",
+            position: { x: 50, y: 50 },
+            config: { text: "Welcome back" }
+          }
+        },
+        edges: {}
+      };
+
+      const result = await updateAgentApi(
+        client,
+        "agent_workflow_123",
+        "Updated Agent with Say",
+        conversation_config,
+        undefined,
+        workflow,
+        ["updated"],
+        "Update Say workflow",
+        "branch_123"
+      );
+
+      expect(result).toEqual({
+        agentId: "agent_workflow_123",
+        versionId: "version_123",
+        branchId: "branch_123"
+      });
+      expect(update).not.toHaveBeenCalled();
+      expect(fetcher).toHaveBeenCalledTimes(1);
+      expect(fetcher).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://api.test/v1/convai/agents/agent_workflow_123",
+          method: "PATCH",
+          queryParameters: { branch_id: "branch_123" },
+          body: expect.objectContaining({
+            name: "Updated Agent with Say",
+            conversation_config: expect.any(Object),
+            workflow: expect.objectContaining({
+              nodes: expect.objectContaining({
+                say_1: expect.objectContaining({
+                  type: "say",
+                  config: { text: "Welcome back" }
+                })
+              })
+            }),
+            tags: ["updated"],
+            version_description: "Update Say workflow"
+          })
         })
       );
     });

--- a/src/shared/elevenlabs-api.ts
+++ b/src/shared/elevenlabs-api.ts
@@ -18,7 +18,7 @@ interface ClientRuntimeOptions {
   headers?: Record<string, HeaderValue>;
   timeoutInSeconds?: number;
   maxRetries?: number;
-  fetch?: typeof fetch;
+  fetch?: typeof globalThis.fetch;
   fetcher?: core.FetchFunction;
   logging?: core.Fetcher.Args['logging'];
 }
@@ -93,7 +93,7 @@ async function getClientRuntimeOptions(client: ElevenLabsClient): Promise<{
   headers: Record<string, string>;
   timeoutInSeconds?: number;
   maxRetries?: number;
-  fetch?: typeof fetch;
+  fetch?: typeof globalThis.fetch;
   fetcher: core.FetchFunction;
   logging?: core.Fetcher.Args['logging'];
 }> {

--- a/src/shared/elevenlabs-api.ts
+++ b/src/shared/elevenlabs-api.ts
@@ -33,14 +33,7 @@ interface RawAgentApiResponse {
   branchId?: string;
 }
 
-const SDK_SUPPORTED_WORKFLOW_NODE_TYPES = new Set([
-  'end',
-  'override_agent',
-  'phone_number',
-  'standalone_agent',
-  'start',
-  'tool'
-]);
+const SDK_MISSING_WORKFLOW_NODE_TYPES = new Set(['say']);
 
 // Type guard for conversational config
 function isConversationalConfig(config: unknown): config is ConversationalConfig {
@@ -56,7 +49,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-function workflowHasSdkUnsupportedNode(workflow: unknown): boolean {
+function workflowHasSdkMissingNode(workflow: unknown): boolean {
   if (!isRecord(workflow) || !isRecord(workflow.nodes)) {
     return false;
   }
@@ -66,7 +59,7 @@ function workflowHasSdkUnsupportedNode(workflow: unknown): boolean {
       return false;
     }
 
-    return !SDK_SUPPORTED_WORKFLOW_NODE_TYPES.has(node.type);
+    return SDK_MISSING_WORKFLOW_NODE_TYPES.has(node.type);
   });
 }
 
@@ -285,7 +278,7 @@ export async function createAgentApi(
   // Normalize workflow to camelCase for API (same as conversationConfig and platformSettings)
   const workflowConfig = workflow ? toCamelCaseKeys(workflow) as AgentWorkflowRequestModel : undefined;
 
-  if (workflowHasSdkUnsupportedNode(workflowConfig)) {
+  if (workflowHasSdkMissingNode(workflowConfig)) {
     const response = await rawAgentRequest(client, 'POST', 'v1/convai/agents/create', toSnakeCaseKeys({
       name,
       conversationConfig: convConfig,
@@ -343,7 +336,7 @@ export async function updateAgentApi(
   // Normalize workflow to camelCase for API (same as conversationConfig and platformSettings)
   const workflowConfig = workflow ? toCamelCaseKeys(workflow) as AgentWorkflowRequestModel : undefined;
 
-  if (workflowHasSdkUnsupportedNode(workflowConfig)) {
+  if (workflowHasSdkMissingNode(workflowConfig)) {
     const response = await rawAgentRequest(
       client,
       'PATCH',

--- a/src/shared/elevenlabs-api.ts
+++ b/src/shared/elevenlabs-api.ts
@@ -1,5 +1,6 @@
-import { ElevenLabsClient } from '@elevenlabs/elevenlabs-js';
+import { ElevenLabsClient, ElevenLabsError } from '@elevenlabs/elevenlabs-js';
 import { ElevenLabs } from '@elevenlabs/elevenlabs-js';
+import * as core from '@elevenlabs/elevenlabs-js/core';
 import {
   ConversationalConfig,
   AgentPlatformSettingsRequestModel,
@@ -7,6 +8,39 @@ import {
 } from '@elevenlabs/elevenlabs-js/api';
 import { getApiKey, loadConfig, Location } from './config.js';
 import { toCamelCaseKeys, toSnakeCaseKeys } from './utils.js';
+
+type Supplier<T> = T | Promise<T> | (() => T | Promise<T>);
+type HeaderValue = string | Supplier<string | null | undefined> | null | undefined;
+
+interface ClientRuntimeOptions {
+  apiKey?: Supplier<string | undefined>;
+  baseUrl?: Supplier<string>;
+  headers?: Record<string, HeaderValue>;
+  timeoutInSeconds?: number;
+  maxRetries?: number;
+  fetch?: typeof fetch;
+  fetcher?: core.FetchFunction;
+  logging?: core.Fetcher.Args['logging'];
+}
+
+interface ClientWithRuntimeOptions {
+  _options?: ClientRuntimeOptions;
+}
+
+interface RawAgentApiResponse {
+  agentId?: string;
+  versionId?: string;
+  branchId?: string;
+}
+
+const SDK_SUPPORTED_WORKFLOW_NODE_TYPES = new Set([
+  'end',
+  'override_agent',
+  'phone_number',
+  'standalone_agent',
+  'start',
+  'tool'
+]);
 
 // Type guard for conversational config
 function isConversationalConfig(config: unknown): config is ConversationalConfig {
@@ -16,6 +50,137 @@ function isConversationalConfig(config: unknown): config is ConversationalConfig
 // Type guard for platform settings
 function isPlatformSettings(settings: unknown): settings is AgentPlatformSettingsRequestModel {
   return typeof settings === 'object' && settings !== null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function workflowHasSdkUnsupportedNode(workflow: unknown): boolean {
+  if (!isRecord(workflow) || !isRecord(workflow.nodes)) {
+    return false;
+  }
+
+  return Object.values(workflow.nodes).some((node) => {
+    if (!isRecord(node) || typeof node.type !== 'string') {
+      return false;
+    }
+
+    return !SDK_SUPPORTED_WORKFLOW_NODE_TYPES.has(node.type);
+  });
+}
+
+async function resolveSupplier<T>(supplier: Supplier<T> | undefined): Promise<T | undefined> {
+  if (typeof supplier === 'function') {
+    return await (supplier as () => T | Promise<T>)();
+  }
+
+  return await supplier;
+}
+
+async function resolveHeaders(headers: Record<string, HeaderValue> | undefined): Promise<Record<string, string>> {
+  const resolvedHeaders: Record<string, string> = {};
+
+  if (!headers) {
+    return resolvedHeaders;
+  }
+
+  for (const [key, value] of Object.entries(headers)) {
+    const resolvedValue = await resolveSupplier(value);
+    if (resolvedValue != null) {
+      resolvedHeaders[key] = resolvedValue;
+    }
+  }
+
+  return resolvedHeaders;
+}
+
+async function getClientRuntimeOptions(client: ElevenLabsClient): Promise<{
+  baseUrl: string;
+  headers: Record<string, string>;
+  timeoutInSeconds?: number;
+  maxRetries?: number;
+  fetch?: typeof fetch;
+  fetcher: core.FetchFunction;
+  logging?: core.Fetcher.Args['logging'];
+}> {
+  const options = (client as unknown as ClientWithRuntimeOptions)._options;
+  const config = await loadConfig();
+  const baseUrl = await resolveSupplier(options?.baseUrl) ?? getApiBaseUrl(config.residency);
+  const headers = await resolveHeaders(options?.headers);
+  const apiKey = await resolveSupplier(options?.apiKey) ?? await getApiKey();
+
+  if (apiKey) {
+    headers['xi-api-key'] = apiKey;
+  }
+
+  return {
+    baseUrl,
+    headers,
+    timeoutInSeconds: options?.timeoutInSeconds,
+    maxRetries: options?.maxRetries,
+    fetch: options?.fetch,
+    fetcher: options?.fetcher ?? core.fetcher,
+    logging: options?.logging
+  };
+}
+
+function throwRawAgentApiError(
+  response: core.APIResponse<unknown, core.Fetcher.Error>,
+  method: string,
+  path: string
+): never {
+  if (response.ok) {
+    throw new Error('Cannot throw an API error for a successful response');
+  }
+
+  if (response.error.reason === 'status-code') {
+    if (response.error.statusCode === 422) {
+      throw new ElevenLabs.UnprocessableEntityError(response.error.body, response.rawResponse);
+    }
+
+    throw new ElevenLabsError({
+      message: `${method} ${path} failed with status ${response.error.statusCode}`,
+      statusCode: response.error.statusCode,
+      body: response.error.body,
+      rawResponse: response.rawResponse
+    });
+  }
+
+  throw new ElevenLabsError({
+    message: `${method} ${path} failed: ${response.error.reason}`,
+    rawResponse: response.rawResponse
+  });
+}
+
+async function rawAgentRequest(
+  client: ElevenLabsClient,
+  method: 'POST' | 'PATCH',
+  path: string,
+  body: Record<string, unknown>,
+  queryParameters?: Record<string, unknown>
+): Promise<RawAgentApiResponse> {
+  const options = await getClientRuntimeOptions(client);
+  const response = await options.fetcher({
+    url: core.url.join(options.baseUrl, path),
+    method,
+    headers: options.headers,
+    contentType: 'application/json',
+    queryParameters,
+    requestType: 'json',
+    responseType: 'json',
+    body,
+    timeoutMs: (options.timeoutInSeconds ?? 240) * 1000,
+    maxRetries: options.maxRetries,
+    fetchFn: options.fetch,
+    logging: options.logging
+  });
+
+  if (!response.ok) {
+    throwRawAgentApiError(response, method, path);
+  }
+
+  return toCamelCaseKeys(response.body) as RawAgentApiResponse;
 }
 
 /**
@@ -120,6 +285,22 @@ export async function createAgentApi(
   // Normalize workflow to camelCase for API (same as conversationConfig and platformSettings)
   const workflowConfig = workflow ? toCamelCaseKeys(workflow) as AgentWorkflowRequestModel : undefined;
 
+  if (workflowHasSdkUnsupportedNode(workflowConfig)) {
+    const response = await rawAgentRequest(client, 'POST', 'v1/convai/agents/create', toSnakeCaseKeys({
+      name,
+      conversationConfig: convConfig,
+      platformSettings,
+      workflow: workflowConfig,
+      tags
+    }));
+
+    if (!response.agentId) {
+      throw new Error('Create agent response did not include agentId');
+    }
+
+    return response.agentId;
+  }
+
   const response = await client.conversationalAi.agents.create({
     name,
     conversationConfig: convConfig,
@@ -161,6 +342,29 @@ export async function updateAgentApi(
   const platformSettings = platformSettingsDict && isPlatformSettings(platformSettingsDict) ? toCamelCaseKeys(platformSettingsDict) as AgentPlatformSettingsRequestModel : undefined;
   // Normalize workflow to camelCase for API (same as conversationConfig and platformSettings)
   const workflowConfig = workflow ? toCamelCaseKeys(workflow) as AgentWorkflowRequestModel : undefined;
+
+  if (workflowHasSdkUnsupportedNode(workflowConfig)) {
+    const response = await rawAgentRequest(
+      client,
+      'PATCH',
+      `v1/convai/agents/${core.url.encodePathParam(agentId)}`,
+      toSnakeCaseKeys({
+        name,
+        conversationConfig: convConfig,
+        platformSettings,
+        workflow: workflowConfig,
+        tags,
+        versionDescription
+      }),
+      branchId ? { branch_id: branchId } : undefined
+    );
+
+    return {
+      agentId: response.agentId ?? agentId,
+      versionId: response.versionId,
+      branchId: response.branchId
+    };
+  }
 
   const response = await client.conversationalAi.agents.update(agentId, {
     name,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Bypass generated SDK workflow-node union validation when pushing workflows containing the SDK-missing `say` node type
- Send affected agent create/update requests through the SDK fetcher with the same normalized request body
- Add regression coverage for creating and updating workflows containing `say` nodes

## Testing
- `pnpm install --frozen-lockfile && pnpm run build && pnpm jest src/__tests__/workflow.test.ts --runInBand`
- `pnpm run build && pnpm run test && pnpm run lint` (passes; lint reports existing no-explicit-any warnings in unrelated test files)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c82206a7-7ea9-442c-b69c-0a624e4f6114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c82206a7-7ea9-442c-b69c-0a624e4f6114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

