### PR TITLE
Bump CLI version to 0.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elevenlabs/cli",
-  "version": "0.5.0",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elevenlabs/cli",
-      "version": "0.5.0",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
         "@elevenlabs/elevenlabs-js": "^2.41.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elevenlabs/cli",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "CLI tool to manage ElevenLabs agents",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## Summary
- bump @elevenlabs/cli from 0.5.2 to 0.5.3
- align package-lock root metadata with the package version

## Verification
- npm run build
- node dist/cli.js --version