### PR TITLE
fix: preserve path_params_schema child keys from case conversion (#90)

### DIFF
--- a/src/__tests__/casing.test.ts
+++ b/src/__tests__/casing.test.ts
@@ -1,4 +1,11 @@
-import { createAgentApi, updateAgentApi, getAgentApi } from "../shared/elevenlabs-api";
+import {
+  createAgentApi,
+  updateAgentApi,
+  getAgentApi,
+  createToolApi,
+  updateToolApi,
+  getToolApi,
+} from "../shared/elevenlabs-api";
 import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
 
 describe("Key casing normalization", () => {
@@ -447,5 +454,131 @@ describe("Key casing normalization", () => {
     // When tool_ids is not present, tools should be preserved
     expect(payload.conversationConfig.agent.prompt).toHaveProperty("tools");
     expect(payload.conversationConfig.agent.prompt.tools).toHaveLength(1);
+  });
+});
+
+// Regression coverage for elevenlabs/cli#90: webhook tools whose URL templates
+// reference path parameters via {{snake_case}} placeholders. The keys of
+// path_params_schema are user-defined identifiers that must match those
+// placeholders, so they must survive the camelCase transform unchanged.
+describe("Webhook tool path_params_schema key preservation (#90)", () => {
+  function makeMockToolClient() {
+    const create = jest.fn().mockResolvedValue({ toolId: "tool_123" });
+    const update = jest.fn().mockResolvedValue({ toolId: "tool_123" });
+    const get = jest.fn();
+    return {
+      conversationalAi: {
+        tools: { create, update, get },
+      },
+    } as unknown as ElevenLabsClient;
+  }
+
+  it("createToolApi preserves path_params_schema child keys (URL placeholder identifiers)", async () => {
+    const client = makeMockToolClient();
+    const toolConfig = {
+      name: "lookup-transaction",
+      description: "Looks up a transaction",
+      type: "webhook",
+      api_schema: {
+        url: "https://api.example.com/transactions/{{transaction_id}}",
+        method: "GET",
+        path_params_schema: {
+          transaction_id: {
+            type: "string",
+            description: "The transaction identifier",
+          },
+        },
+      },
+    } as unknown as Record<string, unknown>;
+
+    await createToolApi(client, toolConfig);
+
+    expect(client.conversationalAi.tools.create).toHaveBeenCalledTimes(1);
+    const payload = (client.conversationalAi.tools.create as jest.Mock).mock
+      .calls[0][0].toolConfig as Record<string, any>;
+
+    // URL string is always preserved; the placeholder must still resolve
+    expect(payload.apiSchema.url).toBe(
+      "https://api.example.com/transactions/{{transaction_id}}"
+    );
+    // path_params_schema top-level key is camelized to pathParamsSchema (envelope convention)
+    expect(payload.apiSchema).toHaveProperty("pathParamsSchema");
+    // User-defined identifier key must be preserved as-is, NOT camelCased to transactionId
+    expect(payload.apiSchema.pathParamsSchema).toHaveProperty("transaction_id");
+    expect(payload.apiSchema.pathParamsSchema).not.toHaveProperty(
+      "transactionId"
+    );
+    // Nested schema fields stay as-is (no underscores to convert here)
+    expect(payload.apiSchema.pathParamsSchema.transaction_id).toEqual({
+      type: "string",
+      description: "The transaction identifier",
+    });
+  });
+
+  it("updateToolApi preserves path_params_schema child keys (URL placeholder identifiers)", async () => {
+    const client = makeMockToolClient();
+    const toolConfig = {
+      name: "lookup-transaction",
+      description: "Looks up a transaction",
+      type: "webhook",
+      api_schema: {
+        url: "https://api.example.com/transactions/{{transaction_id}}",
+        method: "GET",
+        path_params_schema: {
+          transaction_id: {
+            type: "string",
+            description: "The transaction identifier",
+          },
+        },
+      },
+    } as unknown as Record<string, unknown>;
+
+    await updateToolApi(client, "tool_123", toolConfig);
+
+    expect(client.conversationalAi.tools.update).toHaveBeenCalledTimes(1);
+    const [toolId, body] = (client.conversationalAi.tools.update as jest.Mock)
+      .mock.calls[0];
+    expect(toolId).toBe("tool_123");
+    const payload = body.toolConfig as Record<string, any>;
+
+    expect(payload.apiSchema.pathParamsSchema).toHaveProperty("transaction_id");
+    expect(payload.apiSchema.pathParamsSchema).not.toHaveProperty(
+      "transactionId"
+    );
+  });
+
+  it("getToolApi round-trips path_params_schema child keys without corruption", async () => {
+    const get = jest.fn().mockResolvedValue({
+      toolConfig: {
+        name: "lookup-transaction",
+        type: "webhook",
+        apiSchema: {
+          url: "https://api.example.com/transactions/{{transaction_id}}",
+          method: "GET",
+          pathParamsSchema: {
+            transaction_id: {
+              type: "string",
+              description: "The transaction identifier",
+            },
+          },
+        },
+      },
+    });
+    const client = {
+      conversationalAi: { tools: { get } },
+    } as unknown as ElevenLabsClient;
+
+    const response = (await getToolApi(client, "tool_123")) as Record<
+      string,
+      any
+    >;
+
+    // Inbound snake_case conversion for disk must preserve the identifier key
+    expect(response.tool_config.api_schema.path_params_schema).toHaveProperty(
+      "transaction_id"
+    );
+    expect(response.tool_config.api_schema.url).toBe(
+      "https://api.example.com/transactions/{{transaction_id}}"
+    );
   });
 });

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -126,6 +126,7 @@ const PRESERVE_CHILD_KEYS = new Set([
   'language_presets', 'languagePresets',
   'model_usage', 'modelUsage',
   'data_collection', 'dataCollection',
+  'path_params_schema', 'pathParamsSchema',
   'nodes',
   'edges',
 ]);


### PR DESCRIPTION
`path_params_schema` stores user-defined identifiers (e.g. `transaction_id`) whose keys must match the `{{snake_case}}` placeholders in a webhook tool's URL template — the SDK type documents this: *"The keys should match the placeholders in the URL."* On `tools push`, `toCamelCaseKeys` rewrote them to camelCase (`transaction_id` → `transactionId`) while leaving the URL string untouched, so the placeholder no longer resolved and the request broke.

This adds `path_params_schema` / `pathParamsSchema` to `PRESERVE_CHILD_KEYS` so its immediate children pass through unchanged in both push and pull directions — the same pattern used for `data_collection` in #78.

**Tests:** three cases in `casing.test.ts` cover the `createToolApi` / `updateToolApi` push path and the `getToolApi` pull round-trip. The reproduction fails without the fix and passes with it; the full suite stays green.

Thanks @kraenhansen for confirming the fix direction.

**Follow-up — `query_params_schema`:** this is affected by the same class of bug, but it needs a *different* fix and isn't covered here. Unlike `path_params_schema` (a flat `Record<string, …>`), `queryParamsSchema` is a wrapper (`{ properties: Record<string, …>, required }`) whose user-defined keys live one level deeper under `properties`, so adding it to `PRESERVE_CHILD_KEYS` wouldn't preserve them. Worth a separate PR.

Fixes #90
