### PR TITLE
fix: preserve user-defined keys nested below preserved tiers

### DIFF
--- a/src/__tests__/casing.test.ts
+++ b/src/__tests__/casing.test.ts
@@ -1,4 +1,4 @@
-import { createAgentApi, updateAgentApi, getAgentApi } from "../shared/elevenlabs-api";
+import { createAgentApi, updateAgentApi, getAgentApi, createToolApi, updateToolApi, getToolApi } from "../shared/elevenlabs-api";
 import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
 
 describe("Key casing normalization", () => {
@@ -447,5 +447,216 @@ describe("Key casing normalization", () => {
     // When tool_ids is not present, tools should be preserved
     expect(payload.conversationConfig.agent.prompt).toHaveProperty("tools");
     expect(payload.conversationConfig.agent.prompt.tools).toHaveLength(1);
+  });
+
+  function makeToolsMockClient() {
+    const create = jest.fn().mockResolvedValue({ id: "tool_123" });
+    const update = jest.fn().mockResolvedValue({ id: "tool_123" });
+    const get = jest.fn().mockResolvedValue({
+      id: "tool_123",
+      toolConfig: {
+        name: "lookup",
+        type: "webhook",
+        apiSchema: {
+          url: "https://api.example.com/lookup",
+          method: "GET",
+          queryParamsSchema: {
+            properties: {
+              user_id: { type: "string" },
+              sessionToken: { type: "string" },
+            },
+            required: ["user_id", "sessionToken"],
+          },
+        },
+      },
+    });
+
+    return {
+      conversationalAi: {
+        tools: { create, update, get },
+      },
+    } as unknown as ElevenLabsClient;
+  }
+
+  it("createAgentApi camelizes the placeholders wrapper but preserves placeholder names", async () => {
+    const client = makeMockClient();
+    const conversation_config = {
+      agent: {
+        prompt: { prompt: "hi", temperature: 0 },
+        dynamic_variables: {
+          dynamic_variable_placeholders: {
+            transaction_id: "txn_default",
+            verified: false,
+          },
+        },
+      },
+    } as unknown as Record<string, unknown>;
+
+    await createAgentApi(
+      client,
+      "Agent with placeholders",
+      conversation_config,
+      undefined,
+      undefined,
+      []
+    );
+
+    const payload = (client.conversationalAi.agents.create as jest.Mock).mock.calls[0][0];
+    const dynamicVariables = payload.conversationConfig.agent.dynamicVariables;
+
+    // The wrapper is a schema field: it must be camelized or the SDK strips it from the request
+    expect(dynamicVariables).toHaveProperty("dynamicVariablePlaceholders");
+    expect(dynamicVariables).not.toHaveProperty("dynamic_variable_placeholders");
+    // Placeholder names are user-defined identifiers, preserved as-is
+    expect(dynamicVariables.dynamicVariablePlaceholders).toEqual({
+      transaction_id: "txn_default",
+      verified: false,
+    });
+  });
+
+  it("updateAgentApi camelizes the placeholders wrapper but preserves placeholder names", async () => {
+    const client = makeMockClient();
+    const conversation_config = {
+      agent: {
+        prompt: { prompt: "hi", temperature: 0 },
+        dynamic_variables: {
+          dynamic_variable_placeholders: {
+            transaction_id: "txn_default",
+            user_name: "Jan",
+          },
+        },
+      },
+    } as unknown as Record<string, unknown>;
+
+    await updateAgentApi(
+      client,
+      "agent_123",
+      "Updated",
+      conversation_config,
+      undefined,
+      undefined,
+      []
+    );
+
+    const [, payload] = (client.conversationalAi.agents.update as jest.Mock).mock.calls[0];
+    const dynamicVariables = payload.conversationConfig.agent.dynamicVariables;
+
+    expect(dynamicVariables).toHaveProperty("dynamicVariablePlaceholders");
+    expect(dynamicVariables).not.toHaveProperty("dynamic_variable_placeholders");
+    expect(dynamicVariables.dynamicVariablePlaceholders).toEqual({
+      transaction_id: "txn_default",
+      user_name: "Jan",
+    });
+  });
+
+  it("getAgentApi snake_cases the placeholders wrapper and preserves placeholder names", async () => {
+    const getWithPlaceholders = jest.fn().mockResolvedValue({
+      agentId: "agent_123",
+      name: "Test",
+      conversationConfig: {
+        agent: {
+          dynamicVariables: {
+            dynamicVariablePlaceholders: {
+              transaction_id: "txn_default",
+              customerName: "anon",
+            },
+          },
+        },
+      },
+      tags: [],
+    });
+    const client = {
+      conversationalAi: { agents: { get: getWithPlaceholders } },
+    } as unknown as ElevenLabsClient;
+
+    const response = await getAgentApi(client, "agent_123") as Record<string, any>;
+    const dynamicVariables = response.conversation_config.agent.dynamic_variables;
+
+    expect(dynamicVariables).toHaveProperty("dynamic_variable_placeholders");
+    // No round-trip corruption: snake stays snake, camel stays camel
+    expect(dynamicVariables.dynamic_variable_placeholders).toEqual({
+      transaction_id: "txn_default",
+      customerName: "anon",
+    });
+  });
+
+  it("createToolApi preserves query_params_schema property names and required entries", async () => {
+    const client = makeToolsMockClient();
+    const toolConfig = {
+      name: "lookup",
+      type: "webhook",
+      api_schema: {
+        url: "https://api.example.com/lookup",
+        method: "GET",
+        query_params_schema: {
+          properties: {
+            user_id: { type: "string", dynamic_variable: "user_id" },
+          },
+          required: ["user_id"],
+        },
+      },
+    } as unknown as Record<string, unknown>;
+
+    await createToolApi(client, toolConfig);
+
+    const payload = (client.conversationalAi.tools.create as jest.Mock).mock.calls[0][0];
+    const schema = payload.toolConfig.apiSchema.queryParamsSchema;
+
+    // Property names are user-defined, preserved so required[] still matches
+    expect(schema.properties).toHaveProperty("user_id");
+    expect(schema.properties).not.toHaveProperty("userId");
+    // Schema fields within each property definition are still converted
+    expect(schema.properties.user_id).toEqual({ type: "string", dynamicVariable: "user_id" });
+    expect(schema.required).toEqual(["user_id"]);
+  });
+
+  it("updateToolApi preserves request_body_schema property names at all nesting depths", async () => {
+    const client = makeToolsMockClient();
+    const toolConfig = {
+      name: "submit",
+      type: "webhook",
+      api_schema: {
+        url: "https://api.example.com/submit",
+        method: "POST",
+        request_body_schema: {
+          type: "object",
+          properties: {
+            caller_id: { type: "string" },
+            nested_obj: {
+              type: "object",
+              properties: {
+                inner_key: { type: "string" },
+              },
+            },
+          },
+          required: ["caller_id"],
+        },
+      },
+    } as unknown as Record<string, unknown>;
+
+    await updateToolApi(client, "tool_123", toolConfig);
+
+    const [toolId, payload] = (client.conversationalAi.tools.update as jest.Mock).mock.calls[0];
+    expect(toolId).toBe("tool_123");
+    const schema = payload.toolConfig.apiSchema.requestBodySchema;
+
+    expect(schema.properties).toHaveProperty("caller_id");
+    expect(schema.properties).not.toHaveProperty("callerId");
+    expect(schema.properties.nested_obj.properties).toHaveProperty("inner_key");
+    expect(schema.properties.nested_obj.properties).not.toHaveProperty("innerKey");
+    expect(schema.required).toEqual(["caller_id"]);
+  });
+
+  it("getToolApi preserves schema property names on inbound snake_case conversion", async () => {
+    const client = makeToolsMockClient();
+
+    const response = await getToolApi(client, "tool_123") as Record<string, any>;
+    const schema = response.tool_config.api_schema.query_params_schema;
+
+    expect(schema.properties).toHaveProperty("user_id");
+    // camelCase property names must not be snake_cased on pull
+    expect(schema.properties).toHaveProperty("sessionToken");
+    expect(schema.properties).not.toHaveProperty("session_token");
+    expect(schema.required).toEqual(["user_id", "sessionToken"]);
   });
 });

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1078,4 +1078,199 @@ describe("Utils", () => {
       expect(result3).toBe(path.join(tempDir, "My-Agent-2.json"));
     });
   });
+
+  describe("nested preserved-tier keys", () => {
+    it("should camelize the dynamic_variable_placeholders wrapper but preserve placeholder names in toCamelCaseKeys", () => {
+      // Agent configs nest user-defined placeholder names one level below
+      // dynamic_variables: dynamic_variables.dynamic_variable_placeholders.<name>
+      const input = {
+        conversation_config: {
+          agent: {
+            dynamic_variables: {
+              dynamic_variable_placeholders: {
+                transaction_id: "txn_default",
+                user_name: "Jan",
+                verified: false,
+              },
+            },
+          },
+        },
+      };
+
+      const result = toCamelCaseKeys(input);
+
+      expect(result).toEqual({
+        conversationConfig: {
+          agent: {
+            dynamicVariables: {
+              // wrapper is a schema field: converted so the SDK forwards it
+              dynamicVariablePlaceholders: {
+                transaction_id: "txn_default", // preserved - user-defined placeholder name
+                user_name: "Jan",              // preserved - user-defined placeholder name
+                verified: false,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it("should snake_case the dynamicVariablePlaceholders wrapper but preserve placeholder names in toSnakeCaseKeys", () => {
+      const input = {
+        conversationConfig: {
+          agent: {
+            dynamicVariables: {
+              dynamicVariablePlaceholders: {
+                transaction_id: "txn_default",
+                customerName: "anon",
+              },
+            },
+          },
+        },
+      };
+
+      const result = toSnakeCaseKeys(input);
+
+      expect(result).toEqual({
+        conversation_config: {
+          agent: {
+            dynamic_variables: {
+              dynamic_variable_placeholders: {
+                transaction_id: "txn_default", // preserved
+                customerName: "anon",          // preserved - NOT converted to customer_name
+              },
+            },
+          },
+        },
+      });
+    });
+
+    it("should maintain round-trip symmetry for dynamic_variable_placeholders", () => {
+      const original = {
+        conversation_config: {
+          agent: {
+            dynamic_variables: {
+              dynamic_variable_placeholders: {
+                transaction_id: "txn_default",
+                verified: false,
+              },
+            },
+          },
+        },
+      };
+
+      expect(toSnakeCaseKeys(toCamelCaseKeys(original))).toEqual(original);
+    });
+
+    it("should preserve property names under query_params_schema in toCamelCaseKeys", () => {
+      const input = {
+        api_schema: {
+          query_params_schema: {
+            properties: {
+              user_id: { type: "string", dynamic_variable: "user_id" },
+            },
+            required: ["user_id"],
+          },
+        },
+      };
+
+      const result = toCamelCaseKeys(input);
+
+      expect(result).toEqual({
+        apiSchema: {
+          queryParamsSchema: {
+            properties: {
+              // property name preserved, schema fields within converted
+              user_id: { type: "string", dynamicVariable: "user_id" },
+            },
+            required: ["user_id"], // string values untouched - still matches the property
+          },
+        },
+      });
+    });
+
+    it("should preserve property names at every nesting depth of request_body_schema in toCamelCaseKeys", () => {
+      const input = {
+        api_schema: {
+          request_body_schema: {
+            type: "object",
+            properties: {
+              caller_id: { type: "string" },
+              nested_obj: {
+                type: "object",
+                properties: {
+                  inner_key: { type: "string" },
+                },
+              },
+            },
+            required: ["caller_id"],
+          },
+        },
+      };
+
+      const result = toCamelCaseKeys(input);
+
+      expect(result).toEqual({
+        apiSchema: {
+          requestBodySchema: {
+            type: "object",
+            properties: {
+              caller_id: { type: "string" }, // preserved
+              nested_obj: {                  // preserved
+                type: "object",
+                properties: {
+                  inner_key: { type: "string" }, // preserved at depth
+                },
+              },
+            },
+            required: ["caller_id"],
+          },
+        },
+      });
+    });
+
+    it("should preserve property names in toSnakeCaseKeys", () => {
+      const input = {
+        apiSchema: {
+          queryParamsSchema: {
+            properties: {
+              user_id: { type: "string" },
+              sessionToken: { type: "string" },
+            },
+            required: ["user_id", "sessionToken"],
+          },
+        },
+      };
+
+      const result = toSnakeCaseKeys(input);
+
+      expect(result).toEqual({
+        api_schema: {
+          query_params_schema: {
+            properties: {
+              user_id: { type: "string" },
+              sessionToken: { type: "string" }, // preserved - NOT converted to session_token
+            },
+            required: ["user_id", "sessionToken"],
+          },
+        },
+      });
+    });
+
+    it("should maintain round-trip symmetry for schema properties", () => {
+      const original = {
+        api_schema: {
+          request_body_schema: {
+            type: "object",
+            properties: {
+              caller_id: { type: "string" },
+            },
+            required: ["caller_id"],
+          },
+        },
+      };
+
+      expect(toSnakeCaseKeys(toCamelCaseKeys(original))).toEqual(original);
+    });
+  });
 });

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -120,12 +120,17 @@ function toSnakeCaseKey(key: string): string {
 
 // Keys whose children are user-defined identifiers and should not be case-converted.
 // Both snake_case and camelCase variants are listed so the check works in either direction.
+// A preserved-tier key nested directly inside another preserved tier (e.g.
+// dynamic_variable_placeholders under dynamic_variables) is itself converted while its
+// children are preserved; see the 'names-only' handling below.
 const PRESERVE_CHILD_KEYS = new Set([
   'request_headers', 'requestHeaders',
   'dynamic_variables', 'dynamicVariables',
+  'dynamic_variable_placeholders', 'dynamicVariablePlaceholders',
   'language_presets', 'languagePresets',
   'model_usage', 'modelUsage',
   'data_collection', 'dataCollection',
+  'properties',
   'nodes',
   'edges',
 ]);
@@ -141,8 +146,14 @@ export function toCamelCaseKeys<T = unknown>(value: T, skipHeaderConversion: boo
         // Deep inside request_headers: preserve all keys (for backwards compatibility with arrays)
         result[k] = toCamelCaseKeys(v, true);
       } else if (skipHeaderConversion === 'names-only') {
-        // Inside request_headers object: preserve header names (keys) but convert nested objects
-        result[k] = toCamelCaseKeys(v, false);
+        // Inside a preserved tier: keys are user-defined names and stay as-is, unless the
+        // key is itself a preserved-tier key (a schema field wrapping more user-defined
+        // names, e.g. dynamic_variable_placeholders): convert it and preserve ITS children.
+        if (PRESERVE_CHILD_KEYS.has(k)) {
+          result[toCamelCaseKey(k)] = toCamelCaseKeys(v, 'names-only');
+        } else {
+          result[k] = toCamelCaseKeys(v, false);
+        }
       } else {
         // Normal conversion
         result[toCamelCaseKey(k)] = toCamelCaseKeys(v, PRESERVE_CHILD_KEYS.has(k) ? 'names-only' : false);
@@ -164,8 +175,14 @@ export function toSnakeCaseKeys<T = unknown>(value: T, skipHeaderConversion: boo
         // Deep inside request_headers: preserve all keys (for backwards compatibility with arrays)
         result[k] = toSnakeCaseKeys(v, true);
       } else if (skipHeaderConversion === 'names-only') {
-        // Inside request_headers object: preserve header names (keys) but convert nested objects
-        result[k] = toSnakeCaseKeys(v, false);
+        // Inside a preserved tier: keys are user-defined names and stay as-is, unless the
+        // key is itself a preserved-tier key (a schema field wrapping more user-defined
+        // names, e.g. dynamicVariablePlaceholders): convert it and preserve ITS children.
+        if (PRESERVE_CHILD_KEYS.has(k)) {
+          result[toSnakeCaseKey(k)] = toSnakeCaseKeys(v, 'names-only');
+        } else {
+          result[k] = toSnakeCaseKeys(v, false);
+        }
       } else {
         // Normal conversion
         result[toSnakeCaseKey(k)] = toSnakeCaseKeys(v, PRESERVE_CHILD_KEYS.has(k) ? 'names-only' : false);


### PR DESCRIPTION
Fixes #93, fixes #94.

## Problem

The `PRESERVE_CHILD_KEYS` preservation in `toCamelCaseKeys()`/`toSnakeCaseKeys()` is exactly one level deep. Two real bug families live one level lower:

- `dynamic_variables.dynamic_variable_placeholders.<name>`: the wrapper key stays snake_case, the SDK request serializer (`unrecognizedObjectKeys: "strip"`) doesn't recognise it and deletes the whole field, so every placeholder change pushed via the CLI is a silent no-op (#93)
- `query_params_schema.properties.<name>` and `request_body_schema.properties.<name>` (any depth): user-defined property names get camelCased while `required` keeps the original strings (#94)

Before this change:

```
{"dynamicVariables":{"dynamic_variable_placeholders":{"transactionId":"txn_1"}}}   // wrapper stripped by the SDK, names mangled
{"queryParamsSchema":{"properties":{"userId":{...}},"required":["user_id"]}}       // schema inconsistent
```

After:

```
{"dynamicVariables":{"dynamicVariablePlaceholders":{"transaction_id":"txn_1"}}}
{"queryParamsSchema":{"properties":{"user_id":{...}},"required":["user_id"]}}
```

## Fix

- The `'names-only'` mode now consults `PRESERVE_CHILD_KEYS`: a preserved-tier key nested directly inside another preserved tier (e.g. `dynamic_variable_placeholders` under `dynamic_variables`) is converted itself while its children are preserved. Mirrored in `toSnakeCaseKeys`, which fixes the pull direction too
- Added `dynamic_variable_placeholders`/`dynamicVariablePlaceholders` and `properties` to the set. `properties` children are user-defined JSON-schema property names everywhere in this API (checked every `properties` field in the SDK's types; all are user-keyed `Record`s), and because normal-mode recursion re-applies the set at every level, nested `request_body_schema` objects are covered at any depth

Behaviour is unchanged for flat `dynamic_variables` maps (test configs), `request_headers`, `language_presets`, `data_collection`, `model_usage` and `nodes`/`edges`; the existing suite covers these and still passes.

Known limitation: a user-defined key that exactly matches a preserved-tier name (e.g. a `data_collection` item literally named `properties`, or a workflow node named `dynamic_variables`) is now treated as a nested tier inside preserved contexts. That's inherent to any name-based preservation heuristic; flagging it here for the record.

## Tests

13 new tests: 7 transform-level (`utils.test.ts`) and 6 through the real API functions with mock clients (`casing.test.ts`), covering push, pull and round-trip for both families. All 6 seam tests fail on main without the fix. Full suite 215/215, lint and build clean.

Note: built on main independently of #92 (which adds `path_params_schema` to the same set); happy to rebase whichever lands second.
