### PR TITLE
feat: verify pushed config and warn on fields the API did not persist

### DIFF
--- a/src/__tests__/verify.test.ts
+++ b/src/__tests__/verify.test.ts
@@ -1,0 +1,277 @@
+import { findMissingPaths, verifyAgentPush, verifyToolPush } from "../shared/verify";
+import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
+import { ElevenLabs } from "@elevenlabs/elevenlabs-js";
+
+describe("findMissingPaths", () => {
+  it("returns no paths when every expected key persists", () => {
+    const expected = { a: 1, b: { c: "x" } };
+    const actual = { a: 2, b: { c: "y" }, extra: true };
+
+    expect(findMissingPaths(expected, actual)).toEqual([]);
+  });
+
+  it("flags a missing top-level key", () => {
+    const expected = { a: 1, gone: true };
+    const actual = { a: 1 };
+
+    expect(findMissingPaths(expected, actual)).toEqual(["gone"]);
+  });
+
+  it("flags nested missing keys with dotted paths", () => {
+    const expected = {
+      conversation_config: {
+        agent: {
+          dynamic_variables: {
+            dynamic_variable_placeholders: { transaction_id: "x" },
+          },
+        },
+      },
+    };
+    const actual = {
+      conversation_config: {
+        agent: {
+          dynamic_variables: {},
+        },
+      },
+    };
+
+    expect(findMissingPaths(expected, actual)).toEqual([
+      "conversation_config.agent.dynamic_variables.dynamic_variable_placeholders",
+    ]);
+  });
+
+  it("treats arrays and scalars as leaves", () => {
+    const expected = { tags: ["a", "b"], turn_timeout: 7 };
+    const actual = { tags: [], turn_timeout: 30 };
+
+    // Present keys count even when values differ; values are not compared
+    expect(findMissingPaths(expected, actual)).toEqual([]);
+  });
+
+  it("flags every expected child when the actual value is not an object", () => {
+    const expected = { turn: { turn_timeout: 7, turn_model: "turn_v3" } };
+    const actual = { turn: "invalid" };
+
+    expect(findMissingPaths(expected, actual)).toEqual([
+      "turn.turn_timeout",
+      "turn.turn_model",
+    ]);
+  });
+
+  it("flags an expected empty object whose key is absent", () => {
+    const expected = { dynamic_variables: { dynamic_variable_placeholders: {} } };
+    const actual = { dynamic_variables: {} };
+
+    expect(findMissingPaths(expected, actual)).toEqual([
+      "dynamic_variables.dynamic_variable_placeholders",
+    ]);
+  });
+
+  it("returns no paths when expected is not an object", () => {
+    expect(findMissingPaths("scalar", { a: 1 })).toEqual([]);
+    expect(findMissingPaths(null, undefined)).toEqual([]);
+  });
+});
+
+describe("verifyAgentPush", () => {
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  function loggedText(): string {
+    return logSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+  }
+
+  function makeClient(liveResponse: unknown) {
+    const get = jest.fn().mockResolvedValue(liveResponse);
+    return {
+      conversationalAi: { agents: { get } },
+    } as unknown as ElevenLabsClient;
+  }
+
+  it("warns with the dropped field paths when the API did not persist a field", async () => {
+    // Live agent is missing the placeholders the local config carries
+    const client = makeClient({
+      agentId: "agent_123",
+      conversationConfig: {
+        agent: {
+          prompt: { prompt: "hi" },
+          dynamicVariables: {},
+        },
+      },
+    });
+
+    await verifyAgentPush(client, "My Agent", "agent_123", {
+      conversation_config: {
+        agent: {
+          prompt: { prompt: "hi" },
+          dynamic_variables: {
+            dynamic_variable_placeholders: { transaction_id: "x" },
+          },
+        },
+      },
+    });
+
+    const output = loggedText();
+    expect(output).toContain("⚠ My Agent: 1 field(s) in the local config were not persisted");
+    expect(output).toContain("conversation_config.agent.dynamic_variables.dynamic_variable_placeholders");
+    expect(output).toContain("elevenlabs agents pull");
+  });
+
+  it("does not warn when the live config is a superset of the pushed config", async () => {
+    const client = makeClient({
+      agentId: "agent_123",
+      conversationConfig: {
+        agent: { prompt: { prompt: "hi", temperature: 0 } },
+        conversation: { clientEvents: ["audio"] },
+      },
+      platformSettings: { widget: { textInputEnabled: true } },
+      tags: ["prod"],
+    });
+
+    await verifyAgentPush(client, "My Agent", "agent_123", {
+      conversation_config: {
+        agent: { prompt: { prompt: "hi" } },
+      },
+      platform_settings: { widget: { text_input_enabled: true } },
+    });
+
+    expect(loggedText()).not.toContain("⚠");
+  });
+
+  it("does not flag the deprecated 'tools' field when tool_ids is present", async () => {
+    // The push payload intentionally removes 'tools' when 'tool_ids' exists,
+    // so verification must not report it as dropped
+    const client = makeClient({
+      agentId: "agent_123",
+      conversationConfig: {
+        agent: { prompt: { prompt: "hi", toolIds: ["tool_1"] } },
+      },
+    });
+
+    await verifyAgentPush(client, "My Agent", "agent_123", {
+      conversation_config: {
+        agent: {
+          prompt: {
+            prompt: "hi",
+            tools: [{ type: "webhook", name: "legacy" }],
+            tool_ids: ["tool_1"],
+          },
+        },
+      },
+    });
+
+    expect(loggedText()).not.toContain("⚠");
+  });
+
+  it("warns but does not throw when the verification read fails", async () => {
+    const get = jest.fn().mockRejectedValue(new Error("network down"));
+    const client = {
+      conversationalAi: { agents: { get } },
+    } as unknown as ElevenLabsClient;
+
+    await expect(
+      verifyAgentPush(client, "My Agent", "agent_123", {
+        conversation_config: { agent: { prompt: { prompt: "hi" } } },
+      })
+    ).resolves.toBeUndefined();
+
+    expect(loggedText()).toContain("could not verify the pushed config");
+  });
+
+  it("passes the branch id through to the read-back", async () => {
+    const get = jest.fn().mockResolvedValue({ agentId: "agent_123", conversationConfig: {} });
+    const client = {
+      conversationalAi: { agents: { get } },
+    } as unknown as ElevenLabsClient;
+
+    await verifyAgentPush(client, "My Agent", "agent_123", {}, "agtbrch_42");
+
+    expect(get).toHaveBeenCalledWith("agent_123", { branchId: "agtbrch_42" });
+  });
+});
+
+describe("verifyToolPush", () => {
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  function loggedText(): string {
+    return logSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+  }
+
+  function makeToolResponse(toolConfig: unknown): ElevenLabs.ToolResponseModel {
+    return { id: "tool_123", toolConfig } as unknown as ElevenLabs.ToolResponseModel;
+  }
+
+  it("warns when the persisted tool config is missing pushed fields", () => {
+    const response = makeToolResponse({
+      name: "lookup",
+      type: "webhook",
+      apiSchema: { url: "https://api.example.com/lookup" },
+    });
+
+    verifyToolPush("lookup", {
+      name: "lookup",
+      type: "webhook",
+      api_schema: {
+        url: "https://api.example.com/lookup",
+        path_params_schema: { transaction_id: { type: "string" } },
+      },
+    }, response);
+
+    const output = loggedText();
+    expect(output).toContain("⚠ lookup:");
+    expect(output).toContain("api_schema.path_params_schema");
+    expect(output).toContain("elevenlabs tools pull");
+  });
+
+  it("does not warn when every pushed field persisted", () => {
+    const response = makeToolResponse({
+      name: "lookup",
+      type: "webhook",
+      apiSchema: { url: "https://api.example.com/lookup", method: "GET" },
+      responseTimeoutSecs: 30,
+    });
+
+    verifyToolPush("lookup", {
+      name: "lookup",
+      type: "webhook",
+      api_schema: { url: "https://api.example.com/lookup", method: "GET" },
+      response_timeout_secs: 30,
+    }, response);
+
+    expect(loggedText()).not.toContain("⚠");
+  });
+
+  it("truncates long lists of dropped fields", () => {
+    const pushed: Record<string, unknown> = { name: "lookup" };
+    for (let i = 0; i < 12; i++) {
+      pushed[`missing_field_${i}`] = i;
+    }
+
+    verifyToolPush("lookup", pushed, makeToolResponse({ name: "lookup" }));
+
+    const output = loggedText();
+    expect(output).toContain("12 field(s) in the local config were not persisted");
+    expect(output).toContain("... and 2 more");
+  });
+
+  it("warns when the response carries no tool config", () => {
+    verifyToolPush("lookup", { name: "lookup" }, undefined);
+
+    expect(loggedText()).toContain("could not verify the pushed config");
+  });
+});

--- a/src/agents/commands/push-impl.ts
+++ b/src/agents/commands/push-impl.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import fs from 'fs-extra';
 import { readConfig, writeConfig } from '../../shared/utils.js';
 import { getElevenLabsClient, createAgentApi, updateAgentApi, resolveBranchId } from '../../shared/elevenlabs-api.js';
+import { verifyAgentPush } from '../../shared/verify.js';
 import { AgentConfig } from '../templates.js';
 
 const AGENTS_CONFIG_FILE = "agents.json";
@@ -131,6 +132,12 @@ export async function pushAgents(dryRun: boolean = false, agentId?: string, vers
         // Store agent ID in index file
         agentDef.id = newAgentId;
         changesMade = true;
+
+        await verifyAgentPush(client, agentDefName, newAgentId, {
+          conversation_config: conversationConfig as Record<string, unknown>,
+          platform_settings: platformSettings as Record<string, unknown> | undefined,
+          workflow,
+        });
       } else {
         // Update existing agent
         const result = await updateAgentApi(
@@ -149,6 +156,12 @@ export async function pushAgents(dryRun: boolean = false, agentId?: string, vers
         // Update version/branch info
         if (result.versionId) agentDef.version_id = result.versionId;
         if (result.branchId) agentDef.branch_id = result.branchId;
+
+        await verifyAgentPush(client, agentDefName, currentAgentId, {
+          conversation_config: conversationConfig as Record<string, unknown>,
+          platform_settings: platformSettings as Record<string, unknown> | undefined,
+          workflow,
+        }, branchId);
       }
 
       changesMade = true;
@@ -183,6 +196,12 @@ export async function pushAgents(dryRun: boolean = false, agentId?: string, vers
 
             if (branchResult.versionId) branchDef.version_id = branchResult.versionId;
             console.log(`  ✓ Pushed branch '${branchName}'`);
+
+            await verifyAgentPush(client, `${agentDefName} (branch '${branchName}')`, currentAgentId, {
+              conversation_config: branchConversationConfig as Record<string, unknown>,
+              platform_settings: branchPlatformSettings as Record<string, unknown> | undefined,
+              workflow: branchWorkflow,
+            }, branchDef.branch_id);
           } catch (error) {
             console.log(`  ✗ Error pushing branch '${branchName}': ${error}`);
           }

--- a/src/shared/elevenlabs-api.ts
+++ b/src/shared/elevenlabs-api.ts
@@ -23,7 +23,7 @@ function isPlatformSettings(settings: unknown): settings is AgentPlatformSetting
  * Removes the deprecated 'tools' field if 'tool_ids' is present to avoid API conflicts.
  * The API returns both fields, but only accepts one when creating/updating.
  */
-function cleanConversationConfigForApi(config: Record<string, unknown>): Record<string, unknown> {
+export function cleanConversationConfigForApi(config: Record<string, unknown>): Record<string, unknown> {
   const cleaned = { ...config };
 
   // Handle nested agent.prompt structure

--- a/src/shared/verify.ts
+++ b/src/shared/verify.ts
@@ -1,0 +1,130 @@
+import { ElevenLabsClient } from '@elevenlabs/elevenlabs-js';
+import { ElevenLabs } from '@elevenlabs/elevenlabs-js';
+import { getAgentApi, cleanConversationConfigForApi } from './elevenlabs-api.js';
+import { toSnakeCaseKeys } from './utils.js';
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    Object.prototype.toString.call(value) === "[object Object]"
+  );
+}
+
+/**
+ * Collects the key paths from `expected` that are missing in `actual`.
+ *
+ * Presence-only subset check: plain objects are traversed recursively, while
+ * arrays and scalar values are treated as leaves (a present key counts, values
+ * are not compared). Extra keys in `actual` are ignored, since the API merges
+ * updates and fills defaults.
+ *
+ * @param expected - The configuration that was pushed
+ * @param actual - The configuration the API reports as persisted
+ * @param basePath - Path prefix used during recursion
+ * @returns Dotted paths of expected keys that did not persist
+ */
+export function findMissingPaths(expected: unknown, actual: unknown, basePath: string = ''): string[] {
+  if (!isPlainObject(expected)) {
+    return [];
+  }
+
+  const missing: string[] = [];
+
+  for (const [key, expectedValue] of Object.entries(expected)) {
+    const path = basePath ? `${basePath}.${key}` : key;
+    const actualValue = isPlainObject(actual) ? actual[key] : undefined;
+
+    if (actualValue === undefined) {
+      missing.push(path);
+    } else if (isPlainObject(expectedValue)) {
+      missing.push(...findMissingPaths(expectedValue, actualValue, path));
+    }
+  }
+
+  return missing;
+}
+
+function reportMissingFields(label: string, missing: string[], pullCommand: string): void {
+  if (missing.length === 0) {
+    return;
+  }
+
+  const shown = missing.slice(0, 10);
+  console.log(`  ⚠ ${label}: ${missing.length} field(s) in the local config were not persisted by the API:`);
+  for (const path of shown) {
+    console.log(`      - ${path}`);
+  }
+  if (missing.length > shown.length) {
+    console.log(`      ... and ${missing.length - shown.length} more`);
+  }
+  console.log(`    These fields may not be supported by the CLI's bundled SDK. Run '${pullCommand}' to inspect the live config.`);
+}
+
+export interface AgentPushBlocks {
+  conversation_config?: Record<string, unknown>;
+  platform_settings?: Record<string, unknown>;
+  workflow?: unknown;
+}
+
+/**
+ * Reads an agent back after a push and warns about any locally-specified
+ * field the API did not persist. The SDK serializes requests with
+ * unrecognizedObjectKeys: "strip", so fields the bundled SDK does not model
+ * are silently dropped before they reach the API; without a read-back the
+ * CLI would report success regardless. Never fails the push: verification
+ * problems are reported as warnings only.
+ */
+export async function verifyAgentPush(
+  client: ElevenLabsClient,
+  label: string,
+  agentId: string,
+  pushed: AgentPushBlocks,
+  branchId?: string
+): Promise<void> {
+  let live: unknown;
+  try {
+    live = await getAgentApi(client, agentId, branchId);
+  } catch (error) {
+    console.log(`  ⚠ ${label}: could not verify the pushed config: ${error}`);
+    return;
+  }
+
+  const expected: Record<string, unknown> = {};
+  if (pushed.conversation_config) {
+    // Mirror the push payload: the deprecated 'tools' field is removed when
+    // 'tool_ids' is present, so its absence live is intentional
+    expected.conversation_config = cleanConversationConfigForApi(pushed.conversation_config);
+  }
+  if (pushed.platform_settings) {
+    expected.platform_settings = pushed.platform_settings;
+  }
+  if (pushed.workflow !== undefined && pushed.workflow !== null) {
+    expected.workflow = pushed.workflow;
+  }
+
+  // Normalize both sides the same way (getAgentApi already snake_cases the
+  // live config), so only genuinely dropped fields are reported
+  const missing = findMissingPaths(toSnakeCaseKeys(expected), live);
+  reportMissingFields(label, missing, 'elevenlabs agents pull');
+}
+
+/**
+ * Verifies a pushed tool config against the config returned by the API.
+ * Tool create/update responses already contain the persisted tool config,
+ * so no extra API call is needed.
+ */
+export function verifyToolPush(
+  label: string,
+  pushedConfig: Record<string, unknown>,
+  response: ElevenLabs.ToolResponseModel | undefined
+): void {
+  const liveConfig = response?.toolConfig;
+  if (!liveConfig) {
+    console.log(`  ⚠ ${label}: could not verify the pushed config (no tool config in the API response)`);
+    return;
+  }
+
+  const missing = findMissingPaths(toSnakeCaseKeys(pushedConfig), toSnakeCaseKeys(liveConfig));
+  reportMissingFields(label, missing, 'elevenlabs tools pull');
+}

--- a/src/tools/commands/impl.ts
+++ b/src/tools/commands/impl.ts
@@ -17,6 +17,7 @@ import {
   ToolDefinition,
   type Tool
 } from '../../shared/tools.js';
+import { verifyToolPush } from '../../shared/verify.js';
 
 const TOOLS_CONFIG_FILE = "tools.json";
 
@@ -213,13 +214,17 @@ async function pushTools(toolId?: string, dryRun = false): Promise<void> {
         const newToolId = (response as { toolId?: string }).toolId || `tool_${Date.now()}`;
         console.log(`Created tool ${toolDefName} (ID: ${newToolId})`);
 
+        verifyToolPush(toolDefName, toolConfig as Record<string, unknown>, response);
+
         // Store tool ID in index file
         toolDef.id = newToolId;
         changesMade = true;
       } else {
         // Update existing tool
-        await updateToolApi(client, toolId, toolConfig);
+        const response = await updateToolApi(client, toolId, toolConfig);
         console.log(`Updated tool ${toolDefName} (ID: ${toolId})`);
+
+        verifyToolPush(toolDefName, toolConfig as Record<string, unknown>, response);
       }
 
       changesMade = true;


### PR DESCRIPTION
## Problem

Push reports success purely from the HTTP response. The SDK serializes requests with `unrecognizedObjectKeys: "strip"`, so any field the bundled SDK doesn't model (or that reaches it miscased) is silently deleted before the request goes out, and the CLI still prints success. That's the common mechanism behind #90, #93 and #94, and it will recur whenever the platform adds a field before the SDK pin catches up (#82 is the flip side of the same problem).

## Fix

After a successful push, compare what was pushed against what the API reports as persisted, and warn with the exact dropped paths:

- `agents push` reads each agent back after create/update (including branch pushes) and runs a presence-only subset check (every locally specified key must exist live)
- `tools push` checks against the tool config already returned by the create/update response, so no extra API call
- warnings are non-fatal, and a failed verification read never fails the push

Example output:

```
  ⚠ My Agent: 1 field(s) in the local config were not persisted by the API:
      - conversation_config.agent.dynamic_variables.dynamic_variable_placeholders
    These fields may not be supported by the CLI's bundled SDK. Run 'elevenlabs agents pull' to inspect the live config.
```

Design notes:

- presence-only (keys, not values) to avoid false positives from server-side defaults and normalization; arrays are treated as leaves
- the trade-off: it can't see drops where the server always echoes the key with defaults (e.g. the response-only `platform_settings.safety` block) or changes inside arrays; it catches missing keys, which is the dominant failure mode here
- the deprecated `tools`-vs-`tool_ids` cleanup is mirrored on the expected side, so it isn't reported as a drop
- non-goal: detecting local deletions (PATCH merges, so removing a key locally never removes it live; existing behaviour)

## Tests

16 new tests in `verify.test.ts`: unit coverage of the path diff plus the agent/tool verification flows with mock clients (warning fires on a stripped response, silence on a clean push, read failure warns without failing the push). Full suite 218/218, lint and build clean.
