### PR TITLE
Bump CLI version to 0.5.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elevenlabs/cli",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elevenlabs/cli",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "MIT",
       "dependencies": {
         "@elevenlabs/elevenlabs-js": "^2.41.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elevenlabs/cli",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "CLI tool to manage ElevenLabs agents",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
## Summary
- bump @elevenlabs/cli from 0.5.3 to 0.5.4
- align package-lock root metadata with the package version

## Verification
- npm run build
- node dist/cli.js --version