### PR TITLE
Bump CLI version to 0.5.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elevenlabs/cli",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elevenlabs/cli",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "MIT",
       "dependencies": {
         "@elevenlabs/elevenlabs-js": "^2.41.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elevenlabs/cli",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "CLI tool to manage ElevenLabs agents",
   "type": "module",
   "keywords": [


### PR DESCRIPTION
Version bump for the release containing #99 (raw-JSON agent push fixing workflow expression conditions with `llm` / `null_literal` nodes).

Merge after #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)