### PR TITLE
Fix agent templates and bump CLI to 0.5.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elevenlabs/cli",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elevenlabs/cli",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "license": "MIT",
       "dependencies": {
         "@elevenlabs/elevenlabs-js": "^2.41.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elevenlabs/cli",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "CLI tool to manage ElevenLabs agents",
   "type": "module",
   "keywords": [

--- a/src/agents/__tests__/templates.test.ts
+++ b/src/agents/__tests__/templates.test.ts
@@ -1,0 +1,17 @@
+import { getTemplateByName } from "../templates";
+
+describe("agent templates", () => {
+  it.each([
+    "default",
+    "voice-only",
+    "text-only",
+    "customer-service",
+    "assistant"
+  ])("uses Scribe Realtime for the %s template", (templateName) => {
+    const template = getTemplateByName("Test Agent", templateName);
+
+    expect(template.conversation_config.asr).toMatchObject({
+      provider: "scribe_realtime"
+    });
+  });
+});

--- a/src/agents/templates.ts
+++ b/src/agents/templates.ts
@@ -70,7 +70,7 @@ export function getDefaultAgentTemplate(name: string): AgentConfig {
     conversation_config: {
       asr: {
         quality: "high",
-        provider: "elevenlabs",
+        provider: "scribe_realtime",
         user_input_audio_format: "pcm_16000",
         keywords: []
       },
@@ -407,4 +407,4 @@ export function getTemplateByName(name: string, templateType: string = "default"
   }
   
   return templateFunctions[templateType](name);
-} 
+}


### PR DESCRIPTION
## Summary

The CLI default agent template still selects the removed `elevenlabs` ASR provider. This makes `elevenlabs agents add` fail with a 400 response.

This change:

- uses `scribe_realtime` in the default agent template
- adds regression coverage for every template based on the default configuration
- bumps the CLI version from `0.5.5` to `0.5.6`

The minimal template does not set an ASR provider, so it continues to use the server default.

## Testing

Checks completed:

- `npm test` — 243 tests passed
- `npm run build`
- `npm run lint` — no errors; 11 existing warnings