### PR TITLE
feat: agents add + templates show

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,17 @@ your_project/
 # Scaffold a new project (pass a path, or --override to reset an existing one)
 elevenlabs agents init [path] [--override]
 
+# Create an agent from a template (or an existing file), upload it, and register it
+elevenlabs agents add <name> [--template <template>] [--output-path <path>]
+elevenlabs agents add [name] --from-file <path>
+
 # Inspect locally-configured agents
 elevenlabs agents list
 elevenlabs agents status
 
-# List available agent templates
+# List available agent templates, or print one's full configuration
 elevenlabs agents templates list
+elevenlabs agents templates show <template>
 
 # Print an embeddable HTML widget snippet for an agent
 elevenlabs agents widget <agent_id>
@@ -106,11 +111,11 @@ elevenlabs agents delete <agent_id>
 elevenlabs agents delete --all
 ```
 
-> Additional agents-as-code commands (`add`, `push`, `pull`, `test`) and the `tools` / `tests` command groups are being ported from v0 and will land in follow-up changes.
+> Additional agents-as-code commands (`push`, `pull`, `test`) and the `tools` / `tests` command groups are being ported from v0 and will land in follow-up changes.
 
 ### Templates
 
-Pre-built starting configurations, listed by `elevenlabs agents templates list`:
+Pre-built starting configurations for `agents add`, listed by `elevenlabs agents templates list` (inspect one with `agents templates show <template>`):
 
 | Template | Description |
 |----------|-------------|

--- a/cli/elevenlabs/workflow/agents.rs
+++ b/cli/elevenlabs/workflow/agents.rs
@@ -10,9 +10,9 @@ use std::path::{Path, PathBuf};
 use fern_cli_sdk::app::CliApp;
 use fern_cli_sdk::error::CliError;
 use fern_cli_sdk::openapi::AppContext;
-use serde_json::Value;
+use serde_json::{json, Value};
 
-use super::{api, project, settings};
+use super::{api, project, settings, templates};
 
 /// Register the `agents` command group.
 pub fn register(app: CliApp) -> CliApp {
@@ -20,6 +20,12 @@ pub fn register(app: CliApp) -> CliApp {
         &["agents"],
         clap::Command::new("init").about("Initialize a new agent management project"),
         handle_init,
+    )
+    .command_under_typed_with(
+        &["agents"],
+        clap::Command::new("add")
+            .about("Add a new agent: create config, upload to ElevenLabs, and save its ID"),
+        handle_add,
     )
     .command_under_typed_with(
         &["agents"],
@@ -188,6 +194,104 @@ fn io_err(action: &str, path: &Path) -> impl FnOnce(std::io::Error) -> CliError 
     let action = action.to_string();
     let path = path.display().to_string();
     move |e| CliError::Other(anyhow::anyhow!("Could not {action} {path}: {e}"))
+}
+
+// ── add ─────────────────────────────────────────────────────────────
+
+#[derive(clap::Args)]
+struct AddArgs {
+    /// Name of the agent to create.
+    name: Option<String>,
+    /// Custom output path for the config file.
+    #[arg(long = "output-path")]
+    output_path: Option<String>,
+    /// Template to use (default, minimal, voice-only, text-only,
+    /// customer-service, assistant).
+    #[arg(long)]
+    template: Option<String>,
+    /// Create the agent from an existing config file.
+    #[arg(long = "from-file")]
+    from_file: Option<String>,
+}
+
+fn handle_add(args: AddArgs, ctx: &AppContext) -> Result<(), CliError> {
+    if args.from_file.is_some() && args.template.is_some() {
+        return Err(CliError::Validation(
+            "Cannot use both --from-file and --template options together".to_string(),
+        ));
+    }
+    if args.name.is_none() && args.from_file.is_none() {
+        return Err(CliError::Validation(
+            "Agent name is required in non-interactive mode".to_string(),
+        ));
+    }
+
+    let mut registry = require_agents()?;
+
+    // Build the agent config (from a file, or from a template).
+    let (agent_config, agent_name): (Value, String) = if let Some(from_file) = &args.from_file {
+        println!("Loading agent config from '{from_file}'...");
+        let mut cfg = project::read_value(Path::new(from_file)).map_err(|e| {
+            CliError::Validation(format!("Error reading config file '{from_file}': {e}"))
+        })?;
+        let name = args
+            .name
+            .clone()
+            .or_else(|| cfg.get("name").and_then(Value::as_str).map(String::from))
+            .ok_or_else(|| {
+                CliError::Validation(
+                    "Config file has no 'name' and no name was provided".to_string(),
+                )
+            })?;
+        // An explicitly-provided name overrides the file's name.
+        if args.name.is_some() {
+            cfg["name"] = json!(name);
+        }
+        println!("Loaded config for agent: {name}");
+        (cfg, name)
+    } else {
+        let name = args.name.clone().ok_or_else(|| {
+            CliError::Validation("Agent name is required when using templates".to_string())
+        })?;
+        let template_type = args.template.clone().unwrap_or_else(|| "default".to_string());
+        let cfg = templates::template_by_name(&name, &template_type)?;
+        (cfg, name)
+    };
+
+    // Create in ElevenLabs first to obtain an ID.
+    println!("Creating agent '{agent_name}' in ElevenLabs...");
+    let agent_id = api::create_agent(ctx, &agent_config)?;
+    println!("Created agent in ElevenLabs with ID: {agent_id}");
+
+    // Resolve the on-disk config path (custom or generated from the name).
+    let config_path = match &args.output_path {
+        Some(path) => path.clone(),
+        None => project::generate_unique_filename(project::AGENT_CONFIGS_DIR, &agent_name, ".json")
+            .display()
+            .to_string(),
+    };
+    project::write_json(Path::new(&config_path), &agent_config)?;
+    match &args.from_file {
+        Some(from_file) => println!("Created config file: {config_path} (from: {from_file})"),
+        None => println!(
+            "Created config file: {config_path} (template: {})",
+            args.template.as_deref().unwrap_or("default")
+        ),
+    }
+
+    registry.agents.push(project::AgentDefinition {
+        config: config_path.clone(),
+        id: Some(agent_id),
+        branch_id: None,
+        version_id: None,
+        branches: None,
+    });
+    project::save_agents(&registry)?;
+    println!("Added agent '{agent_name}' to agents.json");
+    println!(
+        "Edit {config_path} to customize your agent, then run 'elevenlabs agents push' to update"
+    );
+    Ok(())
 }
 
 // ── list ────────────────────────────────────────────────────────────

--- a/cli/elevenlabs/workflow/templates.rs
+++ b/cli/elevenlabs/workflow/templates.rs
@@ -36,7 +36,7 @@ const DEFAULT_TEMPLATE_JSON: &str = r##"{
     "asr": { "quality": "high", "provider": "scribe_realtime", "user_input_audio_format": "pcm_16000", "keywords": [] },
     "turn": { "turn_timeout": 7.0, "silence_end_call_timeout": -1.0, "mode": "turn" },
     "tts": {
-      "model_id": "eleven_turbo_v2",
+      "model_id": "eleven_flash_v2_5",
       "voice_id": "cjVigY5qzO86Huf0OWal",
       "supported_voices": [],
       "agent_output_audio_format": "pcm_16000",
@@ -171,7 +171,7 @@ fn minimal_template(name: &str) -> Value {
                 "text_only": false
             },
             "tts": {
-                "model_id": "eleven_turbo_v2",
+                "model_id": "eleven_flash_v2_5",
                 "voice_id": "cjVigY5qzO86Huf0OWal"
             }
         },

--- a/cli/elevenlabs/workflow/templates.rs
+++ b/cli/elevenlabs/workflow/templates.rs
@@ -1,12 +1,10 @@
 //! Built-in agent templates and the `agents templates` command group.
-//!
-//! Ports v0's `src/agents/templates.ts`. For now this exposes the
-//! template catalog (`list`); full template bodies and `show` land with
-//! the rest of the `agents` group.
+//! Ports v0's `src/agents/templates.ts`.
 
 use fern_cli_sdk::app::CliApp;
 use fern_cli_sdk::error::CliError;
 use fern_cli_sdk::openapi::AppContext;
+use serde_json::{json, Value};
 
 /// `(name, description)` for every built-in agent template, in display
 /// order. Mirrors v0's `getTemplateOptions()`.
@@ -25,6 +23,238 @@ pub const TEMPLATE_OPTIONS: &[(&str, &str)] = &[
     ("assistant", "General purpose AI assistant configuration"),
 ];
 
+// ── Template bodies ─────────────────────────────────────────────────
+
+/// The complete default agent configuration as raw JSON, with an empty
+/// `name`/`prompt` filled in by [`default_template`]. Stored as a parsed
+/// string rather than the `json!` macro because the structure is deep
+/// enough to blow the macro's recursion limit (and the crate root, where
+/// `#![recursion_limit]` would live, is generated).
+const DEFAULT_TEMPLATE_JSON: &str = r##"{
+  "name": "",
+  "conversation_config": {
+    "asr": { "quality": "high", "provider": "scribe_realtime", "user_input_audio_format": "pcm_16000", "keywords": [] },
+    "turn": { "turn_timeout": 7.0, "silence_end_call_timeout": -1.0, "mode": "turn" },
+    "tts": {
+      "model_id": "eleven_turbo_v2",
+      "voice_id": "cjVigY5qzO86Huf0OWal",
+      "supported_voices": [],
+      "agent_output_audio_format": "pcm_16000",
+      "optimize_streaming_latency": 3,
+      "stability": 0.5,
+      "speed": 1.0,
+      "similarity_boost": 0.8,
+      "pronunciation_dictionary_locators": []
+    },
+    "conversation": { "text_only": false, "max_duration_seconds": 600, "client_events": ["audio", "interruption"] },
+    "language_presets": {},
+    "agent": {
+      "first_message": "",
+      "language": "en",
+      "dynamic_variables": { "dynamic_variable_placeholders": {} },
+      "prompt": {
+        "prompt": "",
+        "llm": "gemini-2.5-flash",
+        "temperature": 0.0,
+        "max_tokens": -1,
+        "tool_ids": [],
+        "mcp_server_ids": [],
+        "native_mcp_server_ids": [],
+        "knowledge_base": [],
+        "ignore_default_personality": false,
+        "rag": {
+          "enabled": false,
+          "embedding_model": "e5_mistral_7b_instruct",
+          "max_vector_distance": 0.6,
+          "max_documents_length": 50000,
+          "max_retrieved_rag_chunks_count": 20
+        },
+        "custom_llm": null
+      }
+    }
+  },
+  "platform_settings": {
+    "auth": { "enable_auth": false, "allowlist": [], "shareable_token": null },
+    "evaluation": { "criteria": [] },
+    "widget": {
+      "variant": "full",
+      "placement": "bottom-right",
+      "expandable": "never",
+      "avatar": { "type": "orb", "color_1": "#2792dc", "color_2": "#9ce6e6" },
+      "feedback_mode": "none",
+      "bg_color": "#ffffff",
+      "text_color": "#000000",
+      "btn_color": "#000000",
+      "btn_text_color": "#ffffff",
+      "border_color": "#e1e1e1",
+      "focus_color": "#000000",
+      "shareable_page_show_terms": true,
+      "show_avatar_when_collapsed": false,
+      "disable_banner": false,
+      "mic_muting_enabled": false,
+      "transcript_enabled": false,
+      "text_input_enabled": true,
+      "text_contents": {
+        "main_label": null, "start_call": null, "new_call": null, "end_call": null,
+        "mute_microphone": null, "change_language": null, "collapse": null, "expand": null,
+        "copied": null, "accept_terms": null, "dismiss_terms": null, "listening_status": null,
+        "speaking_status": null, "connecting_status": null, "input_label": null,
+        "input_placeholder": null, "user_ended_conversation": null, "agent_ended_conversation": null,
+        "conversation_id": null, "error_occurred": null, "copy_id": null
+      },
+      "language_selector": false,
+      "supports_text_only": true,
+      "language_presets": {},
+      "styles": {
+        "base": null, "base_hover": null, "base_active": null, "base_border": null,
+        "base_subtle": null, "base_primary": null, "base_error": null, "accent": null,
+        "accent_hover": null, "accent_active": null, "accent_border": null, "accent_subtle": null,
+        "accent_primary": null, "overlay_padding": null, "button_radius": null, "input_radius": null,
+        "bubble_radius": null, "sheet_radius": null, "compact_sheet_radius": null, "dropdown_sheet_radius": null
+      },
+      "border_radius": null, "btn_radius": null, "action_text": null, "start_call_text": null,
+      "end_call_text": null, "expand_text": null, "listening_text": null, "speaking_text": null,
+      "shareable_page_text": null, "terms_text": null, "terms_html": null, "terms_key": null,
+      "override_link": null, "custom_avatar_path": null
+    },
+    "data_collection": {},
+    "overrides": {
+      "conversation_config_override": {
+        "tts": { "voice_id": false },
+        "conversation": { "text_only": true },
+        "agent": { "first_message": false, "language": false, "prompt": { "prompt": false } }
+      },
+      "custom_llm_extra_body": false,
+      "enable_conversation_initiation_client_data_from_webhook": false
+    },
+    "call_limits": { "agent_concurrency_limit": -1, "daily_limit": 100000, "bursting_enabled": true },
+    "privacy": {
+      "record_voice": true, "retention_days": -1, "delete_transcript_and_pii": false,
+      "delete_audio": false, "apply_to_existing_conversations": false, "zero_retention_mode": false
+    },
+    "workspace_overrides": {
+      "webhooks": { "post_call_webhook_id": null },
+      "conversation_initiation_client_data_webhook": null
+    },
+    "safety": { "is_blocked_ivc": false, "is_blocked_non_ivc": false, "ignore_safety_evaluation": false },
+    "testing": { "attached_tests": [] },
+    "ban": null
+  },
+  "tags": []
+}"##;
+
+/// The complete default agent configuration. Ports
+/// `getDefaultAgentTemplate`.
+fn default_template(name: &str) -> Value {
+    let mut t: Value =
+        serde_json::from_str(DEFAULT_TEMPLATE_JSON).expect("DEFAULT_TEMPLATE_JSON is valid JSON");
+    t["name"] = Value::String(name.to_string());
+    t["conversation_config"]["agent"]["prompt"]["prompt"] =
+        Value::String(format!("You are {name}, a helpful AI assistant."));
+    t
+}
+
+/// Minimal configuration — ports `getMinimalAgentTemplate`.
+fn minimal_template(name: &str) -> Value {
+    json!({
+        "name": name,
+        "conversation_config": {
+            "agent": {
+                "prompt": {
+                    "prompt": format!("You are {name}, a helpful AI assistant."),
+                    "llm": "gemini-2.5-flash",
+                    "temperature": 0.0
+                },
+                "language": "en"
+            },
+            "conversation": {
+                "text_only": false
+            },
+            "tts": {
+                "model_id": "eleven_turbo_v2",
+                "voice_id": "cjVigY5qzO86Huf0OWal"
+            }
+        },
+        "platform_settings": {},
+        "tags": []
+    })
+}
+
+/// Voice-only — ports `getVoiceOnlyTemplate`.
+fn voice_only_template(name: &str) -> Value {
+    let mut t = default_template(name);
+    t["conversation_config"]["conversation"]["text_only"] = json!(false);
+    t["platform_settings"]["widget"]["supports_text_only"] = json!(false);
+    t["platform_settings"]["widget"]["text_input_enabled"] = json!(false);
+    t
+}
+
+/// Text-only — ports `getTextOnlyTemplate`.
+fn text_only_template(name: &str) -> Value {
+    let mut t = default_template(name);
+    t["conversation_config"]["conversation"]["text_only"] = json!(true);
+    t["platform_settings"]["widget"]["supports_text_only"] = json!(true);
+    t["platform_settings"]["overrides"]["conversation_config_override"]["conversation"]
+        ["text_only"] = json!(false);
+    t
+}
+
+/// Customer service — ports `getCustomerServiceTemplate`.
+fn customer_service_template(name: &str) -> Value {
+    let mut t = default_template(name);
+    t["conversation_config"]["agent"]["prompt"]["prompt"] = json!(format!(
+        "You are {name}, a helpful customer service representative. You are professional, \
+         empathetic, and focused on solving customer problems efficiently."
+    ));
+    t["conversation_config"]["agent"]["prompt"]["temperature"] = json!(0.1);
+    t["conversation_config"]["conversation"]["max_duration_seconds"] = json!(1800);
+    t["platform_settings"]["call_limits"]["daily_limit"] = json!(10000);
+    t["platform_settings"]["evaluation"]["criteria"] = json!([
+        "Helpfulness",
+        "Professionalism",
+        "Problem Resolution",
+        "Response Time"
+    ]);
+    t["tags"] = json!(["customer-service"]);
+    t
+}
+
+/// General assistant — ports `getAssistantTemplate`.
+fn assistant_template(name: &str) -> Value {
+    let mut t = default_template(name);
+    t["conversation_config"]["agent"]["prompt"]["prompt"] = json!(format!(
+        "You are {name}, a knowledgeable and helpful AI assistant. You can help with a wide \
+         variety of tasks including answering questions, providing explanations, helping with \
+         analysis, and creative tasks."
+    ));
+    t["conversation_config"]["agent"]["prompt"]["temperature"] = json!(0.3);
+    t["conversation_config"]["agent"]["prompt"]["max_tokens"] = json!(1000);
+    t["tags"] = json!(["assistant", "general-purpose"]);
+    t
+}
+
+/// Build a template by name. Ports `getTemplateByName`; errors on an
+/// unknown template type with the list of available ones.
+pub fn template_by_name(name: &str, template_type: &str) -> Result<Value, CliError> {
+    match template_type {
+        "default" => Ok(default_template(name)),
+        "minimal" => Ok(minimal_template(name)),
+        "voice-only" => Ok(voice_only_template(name)),
+        "text-only" => Ok(text_only_template(name)),
+        "customer-service" => Ok(customer_service_template(name)),
+        "assistant" => Ok(assistant_template(name)),
+        other => {
+            let available: Vec<&str> = TEMPLATE_OPTIONS.iter().map(|(n, _)| *n).collect();
+            Err(CliError::Validation(format!(
+                "Unknown template type '{other}'. Available: {}",
+                available.join(", ")
+            )))
+        }
+    }
+}
+
+// ── Commands ────────────────────────────────────────────────────────
+
 #[derive(clap::Args)]
 struct TemplatesListArgs {}
 
@@ -42,6 +272,25 @@ fn handle_list(_args: TemplatesListArgs, _ctx: &AppContext) -> Result<(), CliErr
     Ok(())
 }
 
+#[derive(clap::Args)]
+struct TemplatesShowArgs {
+    /// Template name to display.
+    template: String,
+}
+
+fn handle_show(args: TemplatesShowArgs, _ctx: &AppContext) -> Result<(), CliError> {
+    let template = template_by_name("Example", &args.template)?;
+    println!("Template: {}", args.template);
+    println!("{}", "=".repeat(50));
+    // v0 prints the template config with a 2-space indent.
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&template)
+            .map_err(|e| CliError::Other(anyhow::anyhow!("Could not render template: {e}")))?
+    );
+    Ok(())
+}
+
 /// Register the `agents templates` command group.
 pub fn register(app: CliApp) -> CliApp {
     app.command_under_typed_with(
@@ -49,4 +298,51 @@ pub fn register(app: CliApp) -> CliApp {
         clap::Command::new("list").about("List available agent templates"),
         handle_list,
     )
+    .command_under_typed_with(
+        &["agents", "templates"],
+        clap::Command::new("show").about("Show a template's full configuration"),
+        handle_show,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn template_by_name_covers_all_options() {
+        for (name, _) in TEMPLATE_OPTIONS {
+            let t = template_by_name("Example", name).expect("template should build");
+            assert_eq!(t["name"], json!("Example"));
+        }
+    }
+
+    #[test]
+    fn unknown_template_errors() {
+        assert!(template_by_name("Example", "nope").is_err());
+    }
+
+    #[test]
+    fn text_only_flips_conversation_flag() {
+        let t = template_by_name("Example", "text-only").unwrap();
+        assert_eq!(
+            t["conversation_config"]["conversation"]["text_only"],
+            json!(true)
+        );
+        assert_eq!(
+            t["platform_settings"]["overrides"]["conversation_config_override"]["conversation"]
+                ["text_only"],
+            json!(false)
+        );
+    }
+
+    #[test]
+    fn customer_service_sets_tags_and_criteria() {
+        let t = template_by_name("Example", "customer-service").unwrap();
+        assert_eq!(t["tags"], json!(["customer-service"]));
+        assert_eq!(
+            t["conversation_config"]["agent"]["prompt"]["temperature"],
+            json!(0.1)
+        );
+    }
 }


### PR DESCRIPTION
## What

Continues the v0 → v1 agents-as-code port (follows #105).

- **`agents add`** — create an agent from a template (`--template`) or an existing config file (`--from-file`), upload it to ElevenLabs via the lossless raw-JSON API, write the config to `agent_configs/`, and register it in `agents.json`. Ports v0's `add.ts` including `--output-path`, `--from-file`/`--template` mutual exclusion, and name resolution (explicit name overrides the file's name).
- **`agents templates show <template>`** — print a template's full configuration.
- **Full template catalog** — all 6 template bodies ported from v0 (`default`, `minimal`, `voice-only`, `text-only`, `customer-service`, `assistant`) + `template_by_name()`, so `add`/`templates` produce byte-for-byte the same configs as v0.

## Implementation note

The large `default` template is parsed from a raw JSON string rather than the `json!` macro — the macro exceeds its recursion limit on a structure this deep, and `#![recursion_limit]` can only live in the (generated) crate root.

## Verified

`cargo build` green; 11 unit tests pass (project + api + templates). Smoke-tested: `templates show <name>` renders each template; `add` validation paths (mutual exclusion, missing name) error correctly. (The `add` create call itself needs a live API key/account to exercise end-to-end.)

## Not yet included (follow-ups)

`agents push`/`pull`/`test` + verify, the `tools`/`tests` command groups, `residency` and `components add`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)