### PR TITLE
fix(ci): stop running every job twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: ci
 
 on:
-  # Only the long-lived branches, so this validates what actually landed.
-  # Without the filter, pushing to a branch that has an open PR runs every job
-  # twice — once for `push`, once for `pull_request` — since the two events use
-  # different refs and so land in different concurrency groups.
   push:
     branches: [next, main]
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,12 @@
 name: ci
 
 on:
+  # Only the long-lived branches, so this validates what actually landed.
+  # Without the filter, pushing to a branch that has an open PR runs every job
+  # twice — once for `push`, once for `pull_request` — since the two events use
+  # different refs and so land in different concurrency groups.
   push:
+    branches: [next, main]
   pull_request:
     types: [opened, synchronize, reopened]
 


### PR DESCRIPTION
## The problem

Every check appeared twice on PRs — `ci / check (pull_request)` and `ci / check (push)`, and so on for `compile` and `test`:

```
✓ ci / check (pull_request)    Successful in 1m
✓ ci / check (push)            Successful in 1m
✓ ci / compile (pull_request)  Successful in 2m
✓ ci / compile (push)          Successful in 2m
✓ ci / test (pull_request)     Successful in 6m
✓ ci / test (push)             Successful in 8m
```

## Cause

`ci.yml` listened to both `push` (unfiltered) and `pull_request`. For a branch with an open PR in the same repo, one `git push` fires **both** events. The `concurrency` group keys on `github.ref`, which differs between them (`refs/heads/<branch>` vs `refs/pull/N/merge`), so the runs land in separate groups and neither cancels the other.

Mine to own: #112 added the `pull_request` trigger without narrowing `push`.

## Fix

Scope `push` to the long-lived branches:

```yaml
push:
  branches: [next, main]
pull_request:
  types: [opened, synchronize, reopened]
```

`next`/`main` are still validated on merge; feature branches are covered by their PR — which is the better signal anyway, since `pull_request` builds the *merge result* rather than just the branch tip. Halves CI time per push, which matters now the wire tests take 6–8 minutes. It also stops `ci` firing on tag pushes (those are `release.yml`'s job).

This PR self-verifies: it should show exactly one run of each check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)