### PR TITLE
security: contain config paths, harden destructive init, bound pagination

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,28 @@ jobs:
       - name: Compile
         run: cargo build
 
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      # A regeneration that adds a dependency without refreshing Cargo.lock
+      # leaves it unresolvable, which silently disables `cargo audit`. Fail here
+      # instead: `--locked` proves the committed lockfile still describes the
+      # dependency graph. The fix is to run `cargo build` and commit the lock.
+      - name: Verify Cargo.lock is complete
+        run: cargo metadata --locked --format-version 1 > /dev/null
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      # Fails on advisories only. Warnings (unmaintained, yanked) are left
+      # non-blocking on purpose: the dependency graph comes from the generator,
+      # so a warning we cannot promptly fix would block every unrelated PR.
+      - name: Audit dependencies
+        run: cargo audit
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,27 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -78,10 +93,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -143,6 +198,20 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -220,6 +289,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,6 +338,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -366,6 +461,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "elevenlabs_sdk"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "bytes",
+ "chrono",
+ "elevenlabs_types",
+ "futures",
+ "pin-project",
+ "reqwest",
+ "reqwest-sse",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
+name = "elevenlabs_types"
+version = "0.0.0"
+dependencies = [
+ "base64",
+ "chrono",
+ "num-bigint",
+ "ordered-float",
+ "reqwest",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,9 +520,9 @@ dependencies = [
  "anyhow",
  "base64",
  "bytes",
+ "clap",
  "clap_complete",
  "clap_mangen",
- "clap",
  "dotenvy",
  "elevenlabs_sdk",
  "form_urlencoded",
@@ -410,21 +536,21 @@ dependencies = [
  "rand 0.8.6",
  "reqwest",
  "secrecy",
- "serde_json_path",
+ "serde",
  "serde_json",
+ "serde_json_path",
  "serde_qs",
  "serde_yaml",
- "serde",
  "serial_test",
  "sha2",
  "tempfile",
  "thiserror 2.0.18",
+ "tokio",
  "tokio-tungstenite",
  "tokio-util",
- "tokio",
+ "tracing",
  "tracing-appender",
  "tracing-subscriber",
- "tracing",
  "unicode-normalization",
  "webbrowser",
  "wiremock",
@@ -435,6 +561,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -771,6 +907,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,6 +1251,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,10 +1314,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "num_cpus"
@@ -1250,6 +1449,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+ "serde",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,6 +1487,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1408,6 +1638,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -1447,6 +1678,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+ "serde",
 ]
 
 [[package]]
@@ -1506,6 +1738,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -1539,6 +1772,19 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "reqwest-sse"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60e0aedd78f3626aad0ac3352f6128b73d3b617080da13fbaf8d168dad82de89"
+dependencies = [
+ "async-stream",
+ "reqwest",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1926,6 +2172,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "simd_cesu8"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2194,6 +2446,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2245,12 +2508,17 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -2618,10 +2886,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2936,27 +3257,3 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "elevenlabs_types"
-version = "0.0.0"
-dependencies = [
- "base64",
- "chrono",
- "num-bigint",
- "ordered-float",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "elevenlabs_sdk"
-version = "0.0.0"
-dependencies = [
- "elevenlabs_types",
- "futures",
- "reqwest",
- "serde",
- "serde_json",
- "tokio",
-]

--- a/cli/elevenlabs/main.rs
+++ b/cli/elevenlabs/main.rs
@@ -9,10 +9,7 @@ use fern_cli_sdk::openapi::OpenApiBinding;
 
 fn main() {
     let app = CliApp::new("elevenlabs")
-        .binding(
-            OpenApiBinding::new()
-                .spec(include_str!("openapi0.json"))
-        );
+        .binding(OpenApiBinding::new().spec(include_str!("openapi0.json")));
 
     let app = custom::register(app);
 

--- a/cli/elevenlabs/workflow/agents.rs
+++ b/cli/elevenlabs/workflow/agents.rs
@@ -53,8 +53,7 @@ pub fn register(app: CliApp) -> CliApp {
     // commands, and a custom leaf named `widget` would shadow the whole group.
     .command_under_typed_with(
         &["agents", "widget"],
-        clap::Command::new("embed")
-            .about("Print an embeddable HTML widget snippet for an agent"),
+        clap::Command::new("embed").about("Print an embeddable HTML widget snippet for an agent"),
         handle_widget,
     )
     .command_under_typed_with(
@@ -100,6 +99,9 @@ struct InitArgs {
     /// Override existing files and recreate config dirs from scratch.
     #[arg(long)]
     r#override: bool,
+    /// Skip the confirmation prompt shown for --override.
+    #[arg(long)]
+    yes: bool,
 }
 
 fn handle_init(args: InitArgs, _ctx: &AppContext) -> Result<(), CliError> {
@@ -109,7 +111,21 @@ fn handle_init(args: InitArgs, _ctx: &AppContext) -> Result<(), CliError> {
         .unwrap_or_else(|_| root.clone());
     println!("Initializing project in {}", abs.display());
     if args.r#override {
+        // --override recursively deletes the config directories, so confirm
+        // first. A non-interactive run declines, which keeps an agent or a
+        // script from wiping a directory it was merely pointed at.
         println!("⚠ Override mode: existing files will be overwritten");
+        println!(
+            "   This deletes {}/, {}/ and {}/ under {} and their contents.",
+            project::AGENT_CONFIGS_DIR,
+            project::TOOL_CONFIGS_DIR,
+            project::TEST_CONFIGS_DIR,
+            abs.display()
+        );
+        if !args.yes && !project::prompt_confirm("Continue?")? {
+            println!("Initialization cancelled");
+            return Ok(());
+        }
     }
 
     std::fs::create_dir_all(&root).map_err(io_err("create project directory", &root))?;
@@ -151,6 +167,25 @@ fn handle_init(args: InitArgs, _ctx: &AppContext) -> Result<(), CliError> {
         }
     }
 
+    // A .gitignore matters here: `pull` writes API responses verbatim, and a
+    // webhook's request_headers can legally contain a literal bearer token, so
+    // these files should not be committed by accident. It also keeps the .env
+    // this scaffold encourages out of git.
+    let gitignore_path = root.join(".gitignore");
+    if !args.r#override && gitignore_path.exists() {
+        println!(".gitignore already exists (skipped)");
+    } else {
+        std::fs::write(
+            &gitignore_path,
+            "# Credentials — never commit these.\n.env\n\n\
+             # Pulled configs can contain secrets (e.g. literal webhook auth headers).\n\
+             # Remove these lines if you intend to track your agent configs in git.\n\
+             agent_configs/\ntool_configs/\ntest_configs/\n",
+        )
+        .map_err(io_err("write .gitignore", &gitignore_path))?;
+        println!("Created .gitignore");
+    }
+
     let env_path = root.join(".env.example");
     if !args.r#override && env_path.exists() {
         println!(".env.example already exists (skipped)");
@@ -185,7 +220,8 @@ fn init_index_file<T: serde::Serialize>(
 fn print_next_steps() {
     println!("\nProject initialized successfully!");
     println!("Next steps:");
-    println!("1. Set your ElevenLabs API key: elevenlabs auth login");
+    println!("1. Set your ElevenLabs API key: export ELEVENLABS_API_KEY=xi-...");
+    println!("   (or copy .env.example to .env and put it there)");
     println!("2. Create an agent: elevenlabs agents add \"My Agent\" --template default");
     println!("3. Create tools: elevenlabs tools add \"My Webhook\" --type webhook");
     println!("4. Create tests: elevenlabs tests add \"My Test\" --template basic-llm");
@@ -263,7 +299,10 @@ fn handle_add(args: AddArgs, ctx: &AppContext) -> Result<(), CliError> {
         let name = args.name.clone().ok_or_else(|| {
             CliError::Validation("Agent name is required when using templates".to_string())
         })?;
-        let template_type = args.template.clone().unwrap_or_else(|| "default".to_string());
+        let template_type = args
+            .template
+            .clone()
+            .unwrap_or_else(|| "default".to_string());
         let cfg = templates::template_by_name(&name, &template_type)?;
         (cfg, name)
     };
@@ -439,7 +478,10 @@ fn handle_test(args: TestArgs, ctx: &AppContext) -> Result<(), CliError> {
         )));
     }
 
-    println!("Running {} test(s) for agent '{agent_name}'...", test_ids.len());
+    println!(
+        "Running {} test(s) for agent '{agent_name}'...",
+        test_ids.len()
+    );
     println!();
 
     let invocation = api::run_tests_on_agent(ctx, &args.agent, &test_ids, None)?;
@@ -759,7 +801,8 @@ fn handle_pull(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliEr
     let agent = opt_string(matches, "agent");
     let branch = opt_string(matches, "branch");
     let all_branches = matches.get_flag("all-branches");
-    let output_dir = opt_string(matches, "output-dir").unwrap_or_else(|| "agent_configs".to_string());
+    let output_dir =
+        opt_string(matches, "output-dir").unwrap_or_else(|| "agent_configs".to_string());
     let dry_run = dry_run_flag(matches);
     let update = matches.get_flag("update");
     let all = matches.get_flag("all");
@@ -825,7 +868,11 @@ fn handle_pull(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliEr
                     .get("agent_id")
                     .or_else(|| a.get("agentId"))
                     .and_then(Value::as_str)?;
-                let name = a.get("name").and_then(Value::as_str).unwrap_or("").to_string();
+                let name = a
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
                 Some((id.to_string(), name))
             })
             .collect()
@@ -835,7 +882,10 @@ fn handle_pull(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliEr
     let mut plan: Vec<(PullAction, String, String, Option<usize>)> = Vec::new();
     let (mut n_create, mut n_update, mut n_skip) = (0usize, 0usize, 0usize);
     for (id, name) in &remote {
-        let existing = registry.agents.iter().position(|a| a.id.as_deref() == Some(id.as_str()));
+        let existing = registry
+            .agents
+            .iter()
+            .position(|a| a.id.as_deref() == Some(id.as_str()));
         let action = plan_pull_action(existing.is_some(), update, all);
         match action {
             PullAction::Create => n_create += 1,
@@ -848,7 +898,9 @@ fn handle_pull(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliEr
     println!("\nPlan: {n_create} create, {n_update} update, {n_skip} skip");
     if n_skip > 0 && !update && !all {
         if n_create == 0 {
-            println!("\n💡 Tip: Use --update to update existing agents or --all to pull everything");
+            println!(
+                "\n💡 Tip: Use --update to update existing agents or --all to pull everything"
+            );
         } else {
             println!("\n💡 Tip: Use --all to also update existing agents");
         }
@@ -866,7 +918,11 @@ fn handle_pull(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliEr
             continue;
         }
         if dry_run {
-            let verb = if *action == PullAction::Update { "update" } else { "pull" };
+            let verb = if *action == PullAction::Update {
+                "update"
+            } else {
+                "pull"
+            };
             println!("[DRY RUN] Would {verb} agent: {name} (ID: {id})");
             continue;
         }
@@ -886,8 +942,14 @@ fn handle_pull(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliEr
             }
         };
         let config = build_pulled_config(name, &live);
-        let version_id = live.get("version_id").and_then(Value::as_str).map(String::from);
-        let live_branch_id = live.get("branch_id").and_then(Value::as_str).map(String::from);
+        let version_id = live
+            .get("version_id")
+            .and_then(Value::as_str)
+            .map(String::from);
+        let live_branch_id = live
+            .get("branch_id")
+            .and_then(Value::as_str)
+            .map(String::from);
 
         let entry_idx = match existing_idx {
             Some(i) => {
@@ -903,10 +965,9 @@ fn handle_pull(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliEr
                 *i
             }
             None => {
-                let cfg_path =
-                    project::generate_unique_filename(&output_dir, name, ".json")
-                        .display()
-                        .to_string();
+                let cfg_path = project::generate_unique_filename(&output_dir, name, ".json")
+                    .display()
+                    .to_string();
                 project::write_json_in_project(&cfg_path, &config)?;
                 registry.agents.push(project::AgentDefinition {
                     config: cfg_path.clone(),
@@ -922,10 +983,13 @@ fn handle_pull(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliEr
 
         // --branch: persist the branch config alongside the main one.
         if let (Some(branch), Some(bid)) = (&branch, &branch_id) {
-            let branch_path =
-                project::generate_unique_filename(&output_dir, &format!("{name}.{branch}"), ".json")
-                    .display()
-                    .to_string();
+            let branch_path = project::generate_unique_filename(
+                &output_dir,
+                &format!("{name}.{branch}"),
+                ".json",
+            )
+            .display()
+            .to_string();
             project::write_json_in_project(&branch_path, &config)?;
             let branches = registry.agents[entry_idx]
                 .branches
@@ -986,7 +1050,11 @@ fn pull_all_branches(
 
     let parent_branch_id = registry.agents[entry_idx].branch_id.clone();
     for branch in &branches {
-        if branch.get("is_archived").and_then(Value::as_bool).unwrap_or(false) {
+        if branch
+            .get("is_archived")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
             continue;
         }
         let bid = branch.get("id").and_then(Value::as_str).unwrap_or("");
@@ -1007,7 +1075,10 @@ fn pull_all_branches(
             }
         };
         let branch_config = build_pulled_config(agent_name, &live);
-        let version_id = live.get("version_id").and_then(Value::as_str).map(String::from);
+        let version_id = live
+            .get("version_id")
+            .and_then(Value::as_str)
+            .map(String::from);
 
         let existing_path = registry.agents[entry_idx]
             .branches
@@ -1054,11 +1125,15 @@ fn build_pulled_config(name: &str, live: &Value) -> Value {
     obj.insert("name".to_string(), json!(name));
     obj.insert(
         "conversation_config".to_string(),
-        live.get("conversation_config").cloned().unwrap_or_else(|| json!({})),
+        live.get("conversation_config")
+            .cloned()
+            .unwrap_or_else(|| json!({})),
     );
     obj.insert(
         "platform_settings".to_string(),
-        live.get("platform_settings").cloned().unwrap_or_else(|| json!({})),
+        live.get("platform_settings")
+            .cloned()
+            .unwrap_or_else(|| json!({})),
     );
     obj.insert(
         "tags".to_string(),
@@ -1090,7 +1165,10 @@ mod tests {
         });
         let config = build_pulled_config("My Agent", &live);
         assert_eq!(config["name"], json!("My Agent"));
-        assert_eq!(config["conversation_config"]["agent"]["language"], json!("en"));
+        assert_eq!(
+            config["conversation_config"]["agent"]["language"],
+            json!("en")
+        );
         assert_eq!(config["tags"], json!(["a"]));
         assert!(config.get("agent_id").is_none());
         assert!(config.get("version_id").is_none());

--- a/cli/elevenlabs/workflow/agents.rs
+++ b/cli/elevenlabs/workflow/agents.rs
@@ -80,7 +80,7 @@ fn require_agents() -> Result<project::AgentsConfig, CliError> {
 /// Read an agent's display name from its config file. Ports v0's
 /// `getAgentName` (Unknown when unreadable, Unnamed when nameless).
 fn agent_display_name(config_path: &str) -> String {
-    match project::read_value(Path::new(config_path)) {
+    match project::read_value_in_project(config_path) {
         Ok(value) => value
             .get("name")
             .and_then(Value::as_str)
@@ -280,7 +280,7 @@ fn handle_add(args: AddArgs, ctx: &AppContext) -> Result<(), CliError> {
             .display()
             .to_string(),
     };
-    project::write_json(Path::new(&config_path), &agent_config)?;
+    project::write_json_in_project(&config_path, &agent_config)?;
     match &args.from_file {
         Some(from_file) => println!("Created config file: {config_path} (from: {from_file})"),
         None => println!(
@@ -575,7 +575,7 @@ fn handle_push(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliEr
             println!("Warning: Config file not found: {config_path}");
             continue;
         }
-        let agent_config = match project::read_value(Path::new(&config_path)) {
+        let agent_config = match project::read_value_in_project(&config_path) {
             Ok(v) => v,
             Err(e) => {
                 println!("Error reading config for {config_path}: {e}");
@@ -667,7 +667,7 @@ fn handle_push(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliEr
                         );
                         continue;
                     }
-                    let branch_config = match project::read_value(Path::new(&branch_def.config)) {
+                    let branch_config = match project::read_value_in_project(&branch_def.config) {
                         Ok(v) => v,
                         Err(e) => {
                             println!("  ✗ Error pushing branch '{branch_name}': {e}");
@@ -892,7 +892,7 @@ fn handle_pull(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliEr
         let entry_idx = match existing_idx {
             Some(i) => {
                 let cfg_path = registry.agents[*i].config.clone();
-                project::write_json(Path::new(&cfg_path), &config)?;
+                project::write_json_in_project(&cfg_path, &config)?;
                 if let Some(v) = &version_id {
                     registry.agents[*i].version_id = Some(v.clone());
                 }
@@ -907,7 +907,7 @@ fn handle_pull(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliEr
                     project::generate_unique_filename(&output_dir, name, ".json")
                         .display()
                         .to_string();
-                project::write_json(Path::new(&cfg_path), &config)?;
+                project::write_json_in_project(&cfg_path, &config)?;
                 registry.agents.push(project::AgentDefinition {
                     config: cfg_path.clone(),
                     id: Some(id.clone()),
@@ -926,7 +926,7 @@ fn handle_pull(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliEr
                 project::generate_unique_filename(&output_dir, &format!("{name}.{branch}"), ".json")
                     .display()
                     .to_string();
-            project::write_json(Path::new(&branch_path), &config)?;
+            project::write_json_in_project(&branch_path, &config)?;
             let branches = registry.agents[entry_idx]
                 .branches
                 .get_or_insert_with(Default::default);
@@ -1019,7 +1019,7 @@ fn pull_all_branches(
                 .display()
                 .to_string()
         });
-        project::write_json(Path::new(&branch_path), &branch_config)?;
+        project::write_json_in_project(&branch_path, &branch_config)?;
 
         let map = registry.agents[entry_idx]
             .branches

--- a/cli/elevenlabs/workflow/agents.rs
+++ b/cli/elevenlabs/workflow/agents.rs
@@ -104,6 +104,17 @@ struct InitArgs {
     yes: bool,
 }
 
+/// Contents of the .gitignore written by `init`.
+///
+/// Only .env is ignored. The config directories are deliberately left tracked:
+/// committing them is the entire point of managing agents as code, and ignoring
+/// them fails silently rather than loudly — agents.json is tracked while the
+/// configs it references are not, so a fresh clone gets an index pointing at
+/// files that do not exist. Secrets belong in .env or in workspace secrets,
+/// which pulled configs reference by locator rather than by value.
+const GITIGNORE_BODY: &str =
+    "# Credentials — never commit these. Use .env.example as the tracked template.\n.env\n";
+
 fn handle_init(args: InitArgs, _ctx: &AppContext) -> Result<(), CliError> {
     let root = PathBuf::from(&args.path);
     let abs = std::env::current_dir()
@@ -167,22 +178,12 @@ fn handle_init(args: InitArgs, _ctx: &AppContext) -> Result<(), CliError> {
         }
     }
 
-    // A .gitignore matters here: `pull` writes API responses verbatim, and a
-    // webhook's request_headers can legally contain a literal bearer token, so
-    // these files should not be committed by accident. It also keeps the .env
-    // this scaffold encourages out of git.
     let gitignore_path = root.join(".gitignore");
     if !args.r#override && gitignore_path.exists() {
         println!(".gitignore already exists (skipped)");
     } else {
-        std::fs::write(
-            &gitignore_path,
-            "# Credentials — never commit these.\n.env\n\n\
-             # Pulled configs can contain secrets (e.g. literal webhook auth headers).\n\
-             # Remove these lines if you intend to track your agent configs in git.\n\
-             agent_configs/\ntool_configs/\ntest_configs/\n",
-        )
-        .map_err(io_err("write .gitignore", &gitignore_path))?;
+        std::fs::write(&gitignore_path, GITIGNORE_BODY)
+            .map_err(io_err("write .gitignore", &gitignore_path))?;
         println!("Created .gitignore");
     }
 
@@ -1150,6 +1151,22 @@ fn build_pulled_config(name: &str, live: &Value) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn gitignore_covers_env_but_never_the_config_dirs() {
+        assert!(GITIGNORE_BODY.lines().any(|l| l.trim() == ".env"));
+        for dir in [
+            project::AGENT_CONFIGS_DIR,
+            project::TOOL_CONFIGS_DIR,
+            project::TEST_CONFIGS_DIR,
+        ] {
+            assert!(
+                !GITIGNORE_BODY.contains(dir),
+                ".gitignore must not ignore {dir}: agents.json would be tracked while \
+                 the configs it references are not, breaking only on a fresh clone"
+            );
+        }
+    }
 
     #[test]
     fn pulled_config_keeps_only_the_on_disk_shape() {

--- a/cli/elevenlabs/workflow/api.rs
+++ b/cli/elevenlabs/workflow/api.rs
@@ -15,6 +15,34 @@ use fern_cli_sdk::openapi::AppContext;
 use reqwest::Method;
 use serde_json::{json, Value};
 
+/// Upper bound on pages any list helper will fetch. A hostile or buggy API
+/// that keeps returning `has_more` with the same cursor would otherwise pin the
+/// CLI in an infinite request loop with unbounded memory growth. The framework
+/// applies the same idea to its own `--page-all` (default 10 pages); these
+/// helpers need their own limit because they don't go through it.
+const MAX_PAGES: usize = 100;
+
+/// Decide whether to fetch another page, and with which cursor.
+///
+/// Split out from the list helpers so the termination guarantees are testable
+/// without an HTTP server: a missing/false `has_more`, an absent `next_cursor`,
+/// or a cursor we have already followed all stop the loop.
+fn advance_cursor(resp: &Value, seen: &mut std::collections::HashSet<String>) -> Option<String> {
+    if !resp
+        .get("has_more")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return None;
+    }
+    let next = resp.get("next_cursor").and_then(Value::as_str)?;
+    // A cursor we have already followed means the API is looping.
+    if !seen.insert(next.to_string()) {
+        return None;
+    }
+    Some(next.to_string())
+}
+
 /// `X-Source` tag v0 attached to every request.
 const X_SOURCE: &str = "agents-cli";
 
@@ -38,12 +66,13 @@ fn raw_request(
     query: Option<Vec<(String, String)>>,
 ) -> Result<Value, CliError> {
     let client = crate::sdk::client(ctx);
-    crate::sdk::block_on(
-        client
-            .agents
-            .http_client
-            .execute_request::<Value>(method, path, body, query, request_options()),
-    )
+    crate::sdk::block_on(client.agents.http_client.execute_request::<Value>(
+        method,
+        path,
+        body,
+        query,
+        request_options(),
+    ))
 }
 
 // ── Config cleaning ─────────────────────────────────────────────────
@@ -178,7 +207,8 @@ pub fn get_agent(
 pub fn list_agents(ctx: &AppContext, search: Option<&str>) -> Result<Vec<Value>, CliError> {
     let mut all = Vec::new();
     let mut cursor: Option<String> = None;
-    loop {
+    let mut seen_cursors: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for page in 0..MAX_PAGES {
         let mut query = vec![("page_size".to_string(), "100".to_string())];
         if let Some(c) = &cursor {
             query.push(("cursor".to_string(), c.clone()));
@@ -190,15 +220,12 @@ pub fn list_agents(ctx: &AppContext, search: Option<&str>) -> Result<Vec<Value>,
         if let Some(agents) = resp.get("agents").and_then(Value::as_array) {
             all.extend(agents.iter().cloned());
         }
-        if !resp.get("has_more").and_then(Value::as_bool).unwrap_or(false) {
-            break;
+        match advance_cursor(&resp, &mut seen_cursors) {
+            Some(next) => cursor = Some(next),
+            None => break,
         }
-        cursor = resp
-            .get("next_cursor")
-            .and_then(Value::as_str)
-            .map(String::from);
-        if cursor.is_none() {
-            break;
+        if page + 1 == MAX_PAGES {
+            eprintln!("Warning: stopped after {MAX_PAGES} pages; results may be incomplete.");
         }
     }
     Ok(all)
@@ -353,7 +380,8 @@ pub fn get_test(ctx: &AppContext, test_id: &str) -> Result<Value, CliError> {
 pub fn list_tests(ctx: &AppContext) -> Result<Vec<Value>, CliError> {
     let mut all = Vec::new();
     let mut cursor: Option<String> = None;
-    loop {
+    let mut seen_cursors: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for page in 0..MAX_PAGES {
         let mut query = vec![("page_size".to_string(), "100".to_string())];
         if let Some(c) = &cursor {
             query.push(("cursor".to_string(), c.clone()));
@@ -368,15 +396,12 @@ pub fn list_tests(ctx: &AppContext) -> Result<Vec<Value>, CliError> {
         if let Some(tests) = resp.get("tests").and_then(Value::as_array) {
             all.extend(tests.iter().cloned());
         }
-        if !resp.get("has_more").and_then(Value::as_bool).unwrap_or(false) {
-            break;
+        match advance_cursor(&resp, &mut seen_cursors) {
+            Some(next) => cursor = Some(next),
+            None => break,
         }
-        cursor = resp
-            .get("next_cursor")
-            .and_then(Value::as_str)
-            .map(String::from);
-        if cursor.is_none() {
-            break;
+        if page + 1 == MAX_PAGES {
+            eprintln!("Warning: stopped after {MAX_PAGES} pages; results may be incomplete.");
         }
     }
     Ok(all)
@@ -455,5 +480,56 @@ mod tests {
         let body = build_agent_body(&json!({ "name": "A" }), None);
         assert_eq!(body["name"], json!("A"));
         assert_eq!(body["conversation_config"], json!({}));
+    }
+
+    fn seen() -> std::collections::HashSet<String> {
+        std::collections::HashSet::new()
+    }
+
+    #[test]
+    fn stops_when_has_more_is_absent_or_false() {
+        assert_eq!(advance_cursor(&json!({}), &mut seen()), None);
+        assert_eq!(
+            advance_cursor(&json!({"has_more": false}), &mut seen()),
+            None
+        );
+    }
+
+    #[test]
+    fn stops_when_has_more_is_a_non_bool() {
+        // A hostile API cannot keep the loop alive with a truthy-looking value.
+        assert_eq!(
+            advance_cursor(&json!({"has_more": "yes"}), &mut seen()),
+            None
+        );
+        assert_eq!(advance_cursor(&json!({"has_more": 1}), &mut seen()), None);
+    }
+
+    #[test]
+    fn stops_when_next_cursor_is_missing_despite_has_more() {
+        let resp = json!({"has_more": true});
+        assert_eq!(advance_cursor(&resp, &mut seen()), None);
+    }
+
+    #[test]
+    fn follows_a_fresh_cursor() {
+        let mut s = seen();
+        let resp = json!({"has_more": true, "next_cursor": "abc"});
+        assert_eq!(advance_cursor(&resp, &mut s), Some("abc".to_string()));
+        assert!(s.contains("abc"));
+    }
+
+    #[test]
+    fn stops_on_a_repeated_cursor() {
+        let mut s = seen();
+        let resp = json!({"has_more": true, "next_cursor": "loop"});
+        assert_eq!(advance_cursor(&resp, &mut s), Some("loop".to_string()));
+        // Same cursor again: the API is looping, so refuse to follow it.
+        assert_eq!(advance_cursor(&resp, &mut s), None);
+    }
+
+    #[test]
+    fn page_cap_is_bounded() {
+        assert!(MAX_PAGES > 0 && MAX_PAGES <= 1000);
     }
 }

--- a/cli/elevenlabs/workflow/components.rs
+++ b/cli/elevenlabs/workflow/components.rs
@@ -9,6 +9,11 @@ use fern_cli_sdk::openapi::AppContext;
 
 const REGISTRY_BASE: &str = "https://ui.elevenlabs.io/r";
 
+/// Pinned rather than `@latest`: this runs `npx`, which downloads and executes
+/// the package with the user's privileges, so an upstream compromise would run
+/// here. Bump deliberately.
+const SHADCN_PACKAGE: &str = "shadcn@2.3.0";
+
 /// Registry component name. Restricted to the characters a registry slug can
 /// contain so it can't inject extra arguments or reshape the URL.
 fn validate_component(name: &str) -> Result<(), CliError> {
@@ -32,7 +37,7 @@ fn validate_component(name: &str) -> Result<(), CliError> {
 /// Windows needs `cmd /C` because `npx` is a `.cmd` shim that
 /// `std::process::Command` won't resolve on its own.
 fn shadcn_argv(url: &str) -> (&'static str, Vec<String>) {
-    let shadcn = ["-y", "shadcn@latest", "add", url].map(str::to_string);
+    let shadcn = ["-y", SHADCN_PACKAGE, "add", url].map(str::to_string);
     if cfg!(windows) {
         let mut args = vec!["/C".to_string(), "npx".to_string()];
         args.extend(shadcn);
@@ -53,7 +58,10 @@ fn handle_add(args: AddArgs, _ctx: &AppContext) -> Result<(), CliError> {
     validate_component(&args.name)?;
     let url = format!("{REGISTRY_BASE}/{}.json", args.name);
 
-    println!("Installing {} from the ElevenLabs UI registry...", args.name);
+    println!(
+        "Installing {} from the ElevenLabs UI registry...",
+        args.name
+    );
     println!("Source: {url}\n");
 
     let (program, argv) = shadcn_argv(&url);
@@ -127,7 +135,7 @@ mod tests {
                 argv,
                 vec![
                     "-y",
-                    "shadcn@latest",
+                    SHADCN_PACKAGE,
                     "add",
                     "https://ui.elevenlabs.io/r/all.json"
                 ]

--- a/cli/elevenlabs/workflow/components.rs
+++ b/cli/elevenlabs/workflow/components.rs
@@ -11,8 +11,9 @@ const REGISTRY_BASE: &str = "https://ui.elevenlabs.io/r";
 
 /// Pinned rather than `@latest`: this runs `npx`, which downloads and executes
 /// the package with the user's privileges, so an upstream compromise would run
-/// here. Bump deliberately.
-const SHADCN_PACKAGE: &str = "shadcn@2.3.0";
+/// here. Tracks the current major, since the registry at `REGISTRY_BASE` is
+/// authored against it — pinning further back breaks `add`. Bump deliberately.
+const SHADCN_PACKAGE: &str = "shadcn@4.16.0";
 
 /// Registry component name. Restricted to the characters a registry slug can
 /// contain so it can't inject extra arguments or reshape the URL.

--- a/cli/elevenlabs/workflow/project.rs
+++ b/cli/elevenlabs/workflow/project.rs
@@ -122,7 +122,11 @@ pub struct TestDefinition {
 fn project_root() -> Result<PathBuf, CliError> {
     std::env::current_dir()
         .and_then(|cwd| cwd.canonicalize())
-        .map_err(|e| CliError::Other(anyhow::anyhow!("Could not determine project directory: {e}")))
+        .map_err(|e| {
+            CliError::Other(anyhow::anyhow!(
+                "Could not determine project directory: {e}"
+            ))
+        })
 }
 
 /// Resolve `.` and `..` without touching the filesystem, so a path that does
@@ -642,7 +646,11 @@ mod tests {
             std::os::unix::fs::symlink(outside.path(), "test_configs/shared").expect("symlink");
 
             let found = discover_json_files("test_configs");
-            assert_eq!(found.len(), 1, "only the real file should be discovered: {found:?}");
+            assert_eq!(
+                found.len(),
+                1,
+                "only the real file should be discovered: {found:?}"
+            );
             assert!(found[0].ends_with("real.json"));
         });
     }
@@ -678,6 +686,9 @@ mod tests {
     fn pretty_string_uses_four_space_indent() {
         let v = serde_json::json!({ "a": { "b": 1 } });
         let s = to_pretty_string(&v).unwrap();
-        assert!(s.contains("\n    \"a\""), "expected 4-space indent, got:\n{s}");
+        assert!(
+            s.contains("\n    \"a\""),
+            "expected 4-space indent, got:\n{s}"
+        );
     }
 }

--- a/cli/elevenlabs/workflow/project.rs
+++ b/cli/elevenlabs/workflow/project.rs
@@ -105,6 +105,191 @@ pub struct TestDefinition {
     pub id: Option<String>,
 }
 
+// ── Path containment ────────────────────────────────────────────────
+//
+// The `config` values in the index files are paths, and those files are meant
+// to be committed and cloned — so they are untrusted input. Without a
+// containment check a hostile `agents.json` / `tools.json` / `tests.json` turns
+// `push` into "read any local JSON and upload it", `pull` into "overwrite any
+// file", and `delete` into "unlink any file". A symlink planted inside the
+// project achieves the same without touching the index at all.
+//
+// Everything the workflow reads, writes, or deletes therefore goes through
+// [`resolve_in_project`] first, and writes/reads use `O_NOFOLLOW` so the kernel
+// refuses a final-component symlink.
+
+/// The project directory that config paths must stay inside.
+fn project_root() -> Result<PathBuf, CliError> {
+    std::env::current_dir()
+        .and_then(|cwd| cwd.canonicalize())
+        .map_err(|e| CliError::Other(anyhow::anyhow!("Could not determine project directory: {e}")))
+}
+
+/// Resolve `.` and `..` without touching the filesystem, so a path that does
+/// not exist yet can still be checked for containment.
+fn lexically_normalize(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                out.pop();
+            }
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+/// Resolve a config path from an index file (or a CLI flag) and refuse anything
+/// that escapes the project directory.
+///
+/// Catches both `../` traversal and symlinked directories: the deepest existing
+/// ancestor is canonicalized, so a symlinked `test_configs/shared` pointing
+/// outside the project is rejected even though the literal path looks local.
+pub fn resolve_in_project(path_str: &str) -> Result<PathBuf, CliError> {
+    if path_str.trim().is_empty() {
+        return Err(CliError::Validation("Config path is empty".to_string()));
+    }
+    if path_str.chars().any(char::is_control) {
+        return Err(CliError::Validation(format!(
+            "Config path contains control characters: {path_str:?}"
+        )));
+    }
+
+    let root = project_root()?;
+    let candidate = {
+        let raw = Path::new(path_str);
+        if raw.is_absolute() {
+            raw.to_path_buf()
+        } else {
+            root.join(raw)
+        }
+    };
+    let normalized = lexically_normalize(&candidate);
+
+    if !normalized.starts_with(&root) {
+        return Err(escaped(path_str, &root));
+    }
+
+    // Canonicalize the deepest ancestor that exists; if a symlink redirects
+    // any component out of the project, this is where it shows up.
+    let mut ancestor = normalized.as_path();
+    let real = loop {
+        match ancestor.canonicalize() {
+            Ok(real) => break real,
+            Err(_) => match ancestor.parent() {
+                Some(parent) => ancestor = parent,
+                // Walked past the root without finding anything real.
+                None => return Err(escaped(path_str, &root)),
+            },
+        }
+    };
+    if !real.starts_with(&root) {
+        return Err(escaped(path_str, &root));
+    }
+
+    Ok(normalized)
+}
+
+fn escaped(path_str: &str, root: &Path) -> CliError {
+    CliError::Validation(format!(
+        "Refusing to use config path '{path_str}': it resolves outside the project directory {}. \
+         Config paths in agents.json / tools.json / tests.json must stay inside the project.",
+        root.display()
+    ))
+}
+
+/// Open a file for writing, refusing to follow a symlink at the final
+/// component. Without this a symlink planted in the project redirects the write
+/// to its target — including creating the target when the link dangles.
+fn create_no_follow(path: &Path) -> Result<std::fs::File, CliError> {
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.custom_flags(libc::O_NOFOLLOW);
+    }
+    #[cfg(not(unix))]
+    {
+        // No O_NOFOLLOW equivalent; check explicitly (racy, but better than nothing).
+        if let Ok(meta) = std::fs::symlink_metadata(path) {
+            if meta.file_type().is_symlink() {
+                return Err(symlink_refused(path));
+            }
+        }
+    }
+    opts.open(path).map_err(|e| {
+        // ELOOP is what O_NOFOLLOW returns for a symlink.
+        #[cfg(unix)]
+        if e.raw_os_error() == Some(libc::ELOOP) {
+            return symlink_refused(path);
+        }
+        CliError::Other(anyhow::anyhow!(
+            "Could not write configuration file to {}: {e}",
+            path.display()
+        ))
+    })
+}
+
+fn symlink_refused(path: &Path) -> CliError {
+    CliError::Validation(format!(
+        "Refusing to write through the symlink at {} — a symlinked config path can redirect \
+         writes outside the project.",
+        path.display()
+    ))
+}
+
+/// Read a config file named by an index file, with containment + symlink checks.
+pub fn read_value_in_project(path_str: &str) -> Result<Value, CliError> {
+    let path = resolve_in_project(path_str)?;
+    if let Ok(meta) = std::fs::symlink_metadata(&path) {
+        if meta.file_type().is_symlink() {
+            return Err(CliError::Validation(format!(
+                "Refusing to read through the symlink at {}",
+                path.display()
+            )));
+        }
+    }
+    read_value(&path)
+}
+
+/// Write a config file named by an index file, with containment + symlink checks.
+pub fn write_json_in_project<T: Serialize>(path_str: &str, value: &T) -> Result<(), CliError> {
+    write_json(&resolve_in_project(path_str)?, value)
+}
+
+/// Delete a config file named by an index file, with containment + symlink
+/// checks. Returns whether a file was removed.
+pub fn remove_in_project(path_str: &str) -> Result<bool, CliError> {
+    let path = resolve_in_project(path_str)?;
+    match std::fs::symlink_metadata(&path) {
+        Err(_) => Ok(false),
+        Ok(meta) if meta.file_type().is_symlink() => Err(CliError::Validation(format!(
+            "Refusing to delete through the symlink at {}",
+            path.display()
+        ))),
+        Ok(meta) if !meta.file_type().is_file() => Err(CliError::Validation(format!(
+            "Refusing to delete {} — not a regular file",
+            path.display()
+        ))),
+        Ok(_) => Ok(std::fs::remove_file(&path).is_ok()),
+    }
+}
+
+/// Config files can hold webhook headers and other sensitive values, so keep
+/// them owner-only (v0 used the same posture for its credential file).
+fn restrict_permissions(file: &std::fs::File) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = file.set_permissions(std::fs::Permissions::from_mode(0o600));
+    }
+    #[cfg(not(unix))]
+    let _ = file;
+}
+
 // ── JSON IO ─────────────────────────────────────────────────────────
 
 /// Read and deserialize a JSON file, with v0-style error messages.
@@ -148,7 +333,13 @@ pub fn to_pretty_string<T: Serialize>(value: &T) -> Result<String, CliError> {
 }
 
 /// Write a value as pretty JSON, creating parent directories as needed.
+///
+/// Refuses to follow a symlink at the final component and writes owner-only:
+/// this is the single primitive every workflow write goes through, so the
+/// guarantee holds even for paths that don't come from an index file (`init`
+/// writing `agents.json`, for instance).
 pub fn write_json<T: Serialize>(path: &Path, value: &T) -> Result<(), CliError> {
+    use std::io::Write;
     if let Some(parent) = path.parent() {
         if !parent.as_os_str().is_empty() {
             std::fs::create_dir_all(parent).map_err(|e| {
@@ -160,7 +351,9 @@ pub fn write_json<T: Serialize>(path: &Path, value: &T) -> Result<(), CliError> 
         }
     }
     let rendered = to_pretty_string(value)?;
-    std::fs::write(path, rendered).map_err(|e| {
+    let mut file = create_no_follow(path)?;
+    restrict_permissions(&file);
+    file.write_all(rendered.as_bytes()).map_err(|e| {
         CliError::Other(anyhow::anyhow!(
             "Could not write configuration file to {}: {e}",
             path.display()
@@ -296,7 +489,16 @@ fn walk_json(dir: &Path, found: &mut Vec<String>) {
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        if path.is_dir() {
+        // Use symlink_metadata, not is_dir()/is_file(): following a symlinked
+        // directory here would let a repo point discovery at files outside the
+        // project, which `tests push` would then upload to the API.
+        let Ok(meta) = std::fs::symlink_metadata(&path) else {
+            continue;
+        };
+        if meta.file_type().is_symlink() {
+            continue;
+        }
+        if meta.is_dir() {
             walk_json(&path, found);
         } else if path.extension().and_then(|e| e.to_str()) == Some("json") {
             // Normalize to posix separators for portable index entries.
@@ -330,6 +532,120 @@ pub fn prompt_confirm(message: &str) -> Result<bool, CliError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── Path containment (security regressions) ─────────────────────
+    //
+    // These lock in fixes for three exploits that were reproduced against the
+    // pre-fix binary: a hostile index file could delete/overwrite/read any
+    // file, and a symlink planted in the project redirected writes outside it.
+
+    fn in_temp_project<T>(body: impl FnOnce(&Path) -> T) -> T {
+        // resolve_in_project is relative to the CWD, so run inside a temp dir.
+        // Serialized via a mutex because CWD is process-global.
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path().canonicalize().expect("canonicalize");
+        let previous = std::env::current_dir().expect("cwd");
+        std::env::set_current_dir(&root).expect("chdir");
+        let result = body(&root);
+        let _ = std::env::set_current_dir(previous);
+        result
+    }
+
+    #[test]
+    fn traversal_out_of_the_project_is_refused() {
+        in_temp_project(|_root| {
+            for escape in ["../victim.txt", "../../etc/passwd", "a/../../outside.json"] {
+                assert!(
+                    resolve_in_project(escape).is_err(),
+                    "{escape} should be refused"
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn absolute_paths_outside_the_project_are_refused() {
+        in_temp_project(|_root| {
+            assert!(resolve_in_project("/etc/passwd").is_err());
+        });
+    }
+
+    #[test]
+    fn ordinary_project_relative_paths_are_allowed() {
+        in_temp_project(|root| {
+            let resolved = resolve_in_project("agent_configs/My-Agent.json").expect("allowed");
+            assert!(resolved.starts_with(root));
+            // A path that doesn't exist yet must still resolve (pull writes new files).
+            assert!(resolve_in_project("agent_configs/nested/new.json").is_ok());
+        });
+    }
+
+    #[test]
+    fn a_symlinked_directory_cannot_smuggle_a_path_out_of_the_project() {
+        in_temp_project(|_root| {
+            let outside = tempfile::tempdir().expect("outside");
+            std::fs::create_dir_all("test_configs").expect("mkdir");
+            #[cfg(unix)]
+            std::os::unix::fs::symlink(outside.path(), "test_configs/shared").expect("symlink");
+            #[cfg(unix)]
+            assert!(
+                resolve_in_project("test_configs/shared/x.json").is_err(),
+                "a symlinked directory must not escape containment"
+            );
+        });
+    }
+
+    #[test]
+    fn writes_refuse_to_follow_a_symlink() {
+        in_temp_project(|_root| {
+            let outside = tempfile::tempdir().expect("outside");
+            let target = outside.path().join("planted.json");
+            #[cfg(unix)]
+            {
+                std::os::unix::fs::symlink(&target, "agents.json").expect("symlink");
+                let err = write_json(Path::new("agents.json"), &serde_json::json!({}));
+                assert!(err.is_err(), "writing through a symlink must be refused");
+                assert!(!target.exists(), "the symlink target must not be created");
+            }
+        });
+    }
+
+    #[test]
+    fn deletes_refuse_to_escape_or_follow_a_symlink() {
+        in_temp_project(|_root| {
+            let outside = tempfile::tempdir().expect("outside");
+            let victim = outside.path().join("victim.txt");
+            std::fs::write(&victim, "keep me").expect("write victim");
+
+            // Direct traversal.
+            assert!(remove_in_project("../victim.txt").is_err());
+            // Via a symlink inside the project.
+            #[cfg(unix)]
+            {
+                std::os::unix::fs::symlink(&victim, "link.json").expect("symlink");
+                assert!(remove_in_project("link.json").is_err());
+            }
+            assert!(victim.exists(), "victim must survive both attempts");
+        });
+    }
+
+    #[test]
+    fn discovery_skips_symlinks() {
+        in_temp_project(|_root| {
+            std::fs::create_dir_all("test_configs").expect("mkdir");
+            std::fs::write("test_configs/real.json", "{}").expect("write");
+            let outside = tempfile::tempdir().expect("outside");
+            std::fs::write(outside.path().join("private.json"), "{}").expect("write");
+            #[cfg(unix)]
+            std::os::unix::fs::symlink(outside.path(), "test_configs/shared").expect("symlink");
+
+            let found = discover_json_files("test_configs");
+            assert_eq!(found.len(), 1, "only the real file should be discovered: {found:?}");
+            assert!(found[0].ends_with("real.json"));
+        });
+    }
 
     #[test]
     fn sanitize_replaces_separators_and_traversal() {

--- a/cli/elevenlabs/workflow/settings.rs
+++ b/cli/elevenlabs/workflow/settings.rs
@@ -14,8 +14,13 @@ use fern_cli_sdk::error::CliError;
 use serde_json::Value;
 
 /// Accepted residency values (matches v0's `LOCATIONS`).
-pub const RESIDENCY_VALUES: &[&str] =
-    &["us", "global", "eu-residency", "in-residency", "sg-residency"];
+pub const RESIDENCY_VALUES: &[&str] = &[
+    "us",
+    "global",
+    "eu-residency",
+    "in-residency",
+    "sg-residency",
+];
 
 pub const DEFAULT_RESIDENCY: &str = "global";
 
@@ -38,11 +43,7 @@ pub fn read_residency() -> String {
     };
     serde_json::from_str::<Value>(&data)
         .ok()
-        .and_then(|v| {
-            v.get("residency")
-                .and_then(Value::as_str)
-                .map(String::from)
-        })
+        .and_then(|v| v.get("residency").and_then(Value::as_str).map(String::from))
         .unwrap_or_else(|| DEFAULT_RESIDENCY.to_string())
 }
 
@@ -53,15 +54,21 @@ pub fn write_residency(residency: &str) -> Result<(), CliError> {
         .ok_or_else(|| CliError::Other(anyhow::anyhow!("Could not determine home directory")))?;
     std::fs::create_dir_all(&dir)
         .map_err(|e| CliError::Other(anyhow::anyhow!("Could not create {}: {e}", dir.display())))?;
+    // Owner-only, matching v0's posture for ~/.elevenlabs. Nothing sensitive
+    // lives here today (api_key is stripped below), but the directory is the
+    // natural home for anything that later does.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700));
+    }
     let path = dir.join("config.json");
 
     let existing = std::fs::read_to_string(&path)
         .ok()
         .and_then(|d| serde_json::from_str::<Value>(&d).ok());
 
-    let rendered = super::project::to_pretty_string(&merge_residency(existing, residency))?;
-    std::fs::write(&path, rendered)
-        .map_err(|e| CliError::Other(anyhow::anyhow!("Could not write {}: {e}", path.display())))
+    super::project::write_json(&path, &merge_residency(existing, residency))
 }
 
 /// Set `residency` on the existing config, preserving unrelated keys and
@@ -72,7 +79,10 @@ fn merge_residency(existing: Option<Value>, residency: &str) -> Value {
     let mut obj = existing
         .and_then(|v| v.as_object().cloned())
         .unwrap_or_default();
-    obj.insert("residency".to_string(), Value::String(residency.to_string()));
+    obj.insert(
+        "residency".to_string(),
+        Value::String(residency.to_string()),
+    );
     obj.remove("api_key");
     Value::Object(obj)
 }

--- a/cli/elevenlabs/workflow/templates.rs
+++ b/cli/elevenlabs/workflow/templates.rs
@@ -13,7 +13,10 @@ pub const TEMPLATE_OPTIONS: &[(&str, &str)] = &[
         "default",
         "Complete configuration with all available fields and sensible defaults",
     ),
-    ("minimal", "Minimal configuration with only essential fields"),
+    (
+        "minimal",
+        "Minimal configuration with only essential fields",
+    ),
     ("voice-only", "Optimized for voice-only conversations"),
     ("text-only", "Optimized for text-only conversations"),
     (

--- a/cli/elevenlabs/workflow/tests.rs
+++ b/cli/elevenlabs/workflow/tests.rs
@@ -183,7 +183,7 @@ fn require_tests() -> Result<project::TestsConfig, CliError> {
 }
 
 fn test_name_from_config(config_path: &str) -> Option<String> {
-    project::read_value(Path::new(config_path))
+    project::read_value_in_project(config_path)
         .ok()
         .and_then(|v| v.get("name").and_then(Value::as_str).map(String::from))
 }
@@ -246,9 +246,17 @@ fn register_discovered(registry: &mut project::TestsConfig, config_dir: &str) ->
     added
 }
 
+/// Delete a config file, refusing paths that escape the project or point at a
+/// symlink. A hostile index file previously turned this into an arbitrary
+/// unlink; failures are surfaced rather than swallowed.
 fn remove_config_file(config_path: &str) -> bool {
-    let path = Path::new(config_path);
-    path.exists() && std::fs::remove_file(path).is_ok()
+    match project::remove_in_project(config_path) {
+        Ok(removed) => removed,
+        Err(e) => {
+            eprintln!("  Warning: {e}");
+            false
+        }
+    }
 }
 
 // ── add ─────────────────────────────────────────────────────────────
@@ -292,7 +300,7 @@ fn handle_add(args: AddArgs, ctx: &AppContext) -> Result<(), CliError> {
             .display()
             .to_string(),
     };
-    project::write_json(Path::new(&config_path), &config)?;
+    project::write_json_in_project(&config_path, &config)?;
     println!("Created config file: {config_path} (template: {})", args.template);
 
     registry.tests.push(project::TestDefinition {
@@ -484,7 +492,7 @@ fn handle_push(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliEr
             println!("Warning: Config file not found: {config_path}");
             continue;
         }
-        let test_config = match project::read_value(Path::new(&config_path)) {
+        let test_config = match project::read_value_in_project(&config_path) {
             Ok(v) => v,
             Err(e) => {
                 println!("Error reading config from {config_path}: {e}");
@@ -682,14 +690,14 @@ fn handle_pull(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliEr
         match existing_idx {
             Some(i) => {
                 let cfg_path = registry.tests[*i].config.clone();
-                project::write_json(Path::new(&cfg_path), &config)?;
+                project::write_json_in_project(&cfg_path, &config)?;
                 println!("  ✓ Updated '{name}' (config: {cfg_path})");
             }
             None => {
                 let cfg_path = project::generate_unique_filename(&output_dir, name, ".json")
                     .display()
                     .to_string();
-                project::write_json(Path::new(&cfg_path), &config)?;
+                project::write_json_in_project(&cfg_path, &config)?;
                 registry.tests.push(project::TestDefinition {
                     config: cfg_path.clone(),
                     test_type,

--- a/cli/elevenlabs/workflow/tests.rs
+++ b/cli/elevenlabs/workflow/tests.rs
@@ -48,8 +48,14 @@ pub fn register(app: CliApp) -> CliApp {
 /// `(name, description)` for every built-in test template, in display
 /// order. Mirrors v0's `getTestTemplateOptions()`.
 pub const TEST_TEMPLATE_OPTIONS: &[(&str, &str)] = &[
-    ("basic-llm", "Basic LLM response test with simple user input"),
-    ("tool", "Tool usage test to verify agent calls specific tools"),
+    (
+        "basic-llm",
+        "Basic LLM response test with simple user input",
+    ),
+    (
+        "tool",
+        "Tool usage test to verify agent calls specific tools",
+    ),
     ("conversation-flow", "Multi-turn conversation flow test"),
     (
         "customer-service",
@@ -235,10 +241,7 @@ fn register_discovered(registry: &mut project::TestsConfig, config_dir: &str) ->
         }
         registry.tests.push(project::TestDefinition {
             config: candidate,
-            test_type: config
-                .get("type")
-                .and_then(Value::as_str)
-                .map(String::from),
+            test_type: config.get("type").and_then(Value::as_str).map(String::from),
             id: config.get("id").and_then(Value::as_str).map(String::from),
         });
         added += 1;
@@ -301,19 +304,21 @@ fn handle_add(args: AddArgs, ctx: &AppContext) -> Result<(), CliError> {
             .to_string(),
     };
     project::write_json_in_project(&config_path, &config)?;
-    println!("Created config file: {config_path} (template: {})", args.template);
+    println!(
+        "Created config file: {config_path} (template: {})",
+        args.template
+    );
 
     registry.tests.push(project::TestDefinition {
         config: config_path.clone(),
-        test_type: config
-            .get("type")
-            .and_then(Value::as_str)
-            .map(String::from),
+        test_type: config.get("type").and_then(Value::as_str).map(String::from),
         id: Some(test_id),
     });
     project::save_tests(&registry)?;
     println!("Added test '{}' to tests.json", args.name);
-    println!("Edit {config_path} to customize your test, then run 'elevenlabs tests push' to update");
+    println!(
+        "Edit {config_path} to customize your test, then run 'elevenlabs tests push' to update"
+    );
     Ok(())
 }
 
@@ -507,7 +512,11 @@ fn handle_push(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliEr
 
         println!("{name}: Will push (force override)");
         if dry_run {
-            let verb = if current_id.is_some() { "update" } else { "create" };
+            let verb = if current_id.is_some() {
+                "update"
+            } else {
+                "create"
+            };
             println!("[DRY RUN] Would {verb} test: {name}");
             continue;
         }
@@ -619,7 +628,11 @@ fn handle_pull(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliEr
         list.iter()
             .filter_map(|t| {
                 let id = test_id_of(t)?;
-                let name = t.get("name").and_then(Value::as_str).unwrap_or("").to_string();
+                let name = t
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
                 Some((id, name))
             })
             .collect()
@@ -663,7 +676,11 @@ fn handle_pull(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliEr
             continue;
         }
         if dry_run {
-            let verb = if *action == PullAction::Update { "update" } else { "pull" };
+            let verb = if *action == PullAction::Update {
+                "update"
+            } else {
+                "pull"
+            };
             println!("[DRY RUN] Would {verb} test: {name} (ID: {id})");
             continue;
         }
@@ -682,10 +699,7 @@ fn handle_pull(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliEr
                 continue;
             }
         };
-        let test_type = config
-            .get("type")
-            .and_then(Value::as_str)
-            .map(String::from);
+        let test_type = config.get("type").and_then(Value::as_str).map(String::from);
 
         match existing_idx {
             Some(i) => {
@@ -779,7 +793,10 @@ mod id_tests {
     #[test]
     fn test_id_tolerates_both_spellings() {
         assert_eq!(test_id_of(&json!({ "id": "t1" })), Some("t1".to_string()));
-        assert_eq!(test_id_of(&json!({ "test_id": "t2" })), Some("t2".to_string()));
+        assert_eq!(
+            test_id_of(&json!({ "test_id": "t2" })),
+            Some("t2".to_string())
+        );
         assert_eq!(test_id_of(&json!({ "name": "none" })), None);
     }
 }

--- a/cli/elevenlabs/workflow/tools.rs
+++ b/cli/elevenlabs/workflow/tools.rs
@@ -49,7 +49,7 @@ fn require_tools() -> Result<project::ToolsConfig, CliError> {
 }
 
 fn tool_name_from_config(config_path: &str) -> Option<String> {
-    project::read_value(Path::new(config_path))
+    project::read_value_in_project(config_path)
         .ok()
         .and_then(|v| v.get("name").and_then(Value::as_str).map(String::from))
 }
@@ -158,7 +158,7 @@ fn handle_add(args: AddArgs, ctx: &AppContext) -> Result<(), CliError> {
             .display()
             .to_string(),
     };
-    project::write_json(Path::new(&config_path), &config)?;
+    project::write_json_in_project(&config_path, &config)?;
     println!("Created config file: {config_path}");
 
     registry.tools.push(project::ToolDefinition {
@@ -274,12 +274,16 @@ fn handle_delete(args: DeleteArgs, ctx: &AppContext) -> Result<(), CliError> {
     Ok(())
 }
 
+/// Delete a config file, refusing paths that escape the project or point at a
+/// symlink. A hostile index file previously turned this into an arbitrary
+/// unlink; failures are surfaced rather than swallowed.
 fn remove_config_file(config_path: &str) -> bool {
-    let path = Path::new(config_path);
-    if path.exists() {
-        std::fs::remove_file(path).is_ok()
-    } else {
-        false
+    match project::remove_in_project(config_path) {
+        Ok(removed) => removed,
+        Err(e) => {
+            eprintln!("  Warning: {e}");
+            false
+        }
     }
 }
 
@@ -334,7 +338,7 @@ fn handle_push(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliEr
             println!("Warning: Config file not found: {config_path}");
             continue;
         }
-        let tool_config = match project::read_value(Path::new(&config_path)) {
+        let tool_config = match project::read_value_in_project(&config_path) {
             Ok(v) => v,
             Err(e) => {
                 println!("Error reading config from {config_path}: {e}");
@@ -539,14 +543,14 @@ fn handle_pull(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliEr
         match existing_idx {
             Some(i) => {
                 let cfg_path = registry.tools[*i].config.clone();
-                project::write_json(Path::new(&cfg_path), &tool_config)?;
+                project::write_json_in_project(&cfg_path, &tool_config)?;
                 println!("  ✓ Updated '{name}' (config: {cfg_path})");
             }
             None => {
                 let cfg_path = project::generate_unique_filename(&output_dir, name, ".json")
                     .display()
                     .to_string();
-                project::write_json(Path::new(&cfg_path), &tool_config)?;
+                project::write_json_in_project(&cfg_path, &tool_config)?;
                 registry.tools.push(project::ToolDefinition {
                     tool_type: tool_type.clone(),
                     config: cfg_path.clone(),

--- a/cli/elevenlabs/workflow/tools.rs
+++ b/cli/elevenlabs/workflow/tools.rs
@@ -168,7 +168,9 @@ fn handle_add(args: AddArgs, ctx: &AppContext) -> Result<(), CliError> {
     });
     project::save_tools(&registry)?;
     println!("Added tool '{}' to tools.json", args.name);
-    println!("Edit {config_path} to customize your tool, then run 'elevenlabs tools push' to update");
+    println!(
+        "Edit {config_path} to customize your tool, then run 'elevenlabs tools push' to update"
+    );
     Ok(())
 }
 
@@ -480,7 +482,10 @@ fn handle_pull(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliEr
     let mut plan: Vec<(PullAction, String, String, Option<usize>)> = Vec::new();
     let (mut n_create, mut n_update, mut n_skip) = (0usize, 0usize, 0usize);
     for (id, name) in &remote {
-        let existing = registry.tools.iter().position(|t| t.id.as_deref() == Some(id.as_str()));
+        let existing = registry
+            .tools
+            .iter()
+            .position(|t| t.id.as_deref() == Some(id.as_str()));
         let action = plan_pull_action(existing.is_some(), update, all);
         match action {
             PullAction::Create => n_create += 1,
@@ -511,7 +516,11 @@ fn handle_pull(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliEr
             continue;
         }
         if dry_run {
-            let verb = if *action == PullAction::Update { "update" } else { "pull" };
+            let verb = if *action == PullAction::Update {
+                "update"
+            } else {
+                "pull"
+            };
             println!("[DRY RUN] Would {verb} tool: {name} (ID: {id})");
             continue;
         }
@@ -587,8 +596,14 @@ mod tests {
     #[test]
     fn tool_id_tolerates_every_spelling_the_api_uses() {
         assert_eq!(tool_id_of(&json!({ "id": "t1" })), Some("t1".to_string()));
-        assert_eq!(tool_id_of(&json!({ "tool_id": "t2" })), Some("t2".to_string()));
-        assert_eq!(tool_id_of(&json!({ "toolId": "t3" })), Some("t3".to_string()));
+        assert_eq!(
+            tool_id_of(&json!({ "tool_id": "t2" })),
+            Some("t2".to_string())
+        );
+        assert_eq!(
+            tool_id_of(&json!({ "toolId": "t3" })),
+            Some("t3".to_string())
+        );
         assert_eq!(tool_id_of(&json!({ "name": "no id here" })), None);
     }
 

--- a/cli/elevenlabs/workflow/util.rs
+++ b/cli/elevenlabs/workflow/util.rs
@@ -56,7 +56,11 @@ mod tests {
 
     fn matches_from(args: &[&str]) -> clap::ArgMatches {
         clap::Command::new("test")
-            .arg(clap::Arg::new("dry-run").long("dry-run").action(clap::ArgAction::SetTrue))
+            .arg(
+                clap::Arg::new("dry-run")
+                    .long("dry-run")
+                    .action(clap::ArgAction::SetTrue),
+            )
             .arg(clap::Arg::new("agent").long("agent"))
             .get_matches_from(args)
     }


### PR DESCRIPTION
Remediates the findings from the security review of `next` that are in code we own. Each fix has a regression test; the exploit for every finding below was reproduced against a build of `next` before fixing.

## Path traversal / symlink following (high)

`agents.json`, `tools.json` and `tests.json` hold *paths*, and those files are attacker-controllable in the threat model that matters here — the CLI is expected to be driven by agents, so it will run in checked-out repositories that the operator did not write. A `config` entry of `../../../../etc/crontab`, or a `test_configs/` symlink pointing outside the project, was followed on both read and write.

- `resolve_in_project` normalizes `..` lexically first, then canonicalizes the deepest existing ancestor, so containment holds for paths that do not exist yet.
- Writes go through `O_NOFOLLOW`; `ELOOP` is reported as a refused symlink rather than a generic IO error.
- The tree walk uses `symlink_metadata` and skips symlinks instead of descending through them.

The `O_NOFOLLOW` hardening had to land in the base `write_json` primitive, not just the containment wrapper — `agents init` writes index files through it directly and was still following symlinks until then.

**Behaviour change worth a conscious decision:** a config file that *is* a symlink is now refused rather than written through. Sharing one config across repos by symlinking it no longer works. Only the final path component is affected, so symlinked parent directories still resolve normally.

## Destructive `init --override` (medium)

`agents init --override` recursively deleted `agent_configs/`, `tool_configs/` and `test_configs/` with no confirmation, so a single mistyped flag destroyed local work. It now prompts, with `--yes` for automation; a non-interactive run declines rather than proceeding.

## Unbounded pagination (medium)

`list_agents` and `list_tests` looped on `has_more` with no page cap and no cursor tracking, so an API returning the same cursor forever pinned the CLI in an infinite request loop with unbounded memory growth. Termination is now a pure `advance_cursor` — page cap plus repeated-cursor detection — which also makes the guarantees unit-testable without standing up a server.

Trade-off: this converts "hangs forever" into "may be incomplete". The cap is 100 pages × 100 per page, so a workspace with more than 10,000 agents now truncates with a warning on stderr instead of listing everything.

## Unpinned remote code execution (medium)

`components add` ran `npx -y shadcn@latest`, executing whatever the registry served at that moment with the user's privileges. Now pinned to a specific release, which tracks the current major since the registry at `ui.elevenlabs.io` is authored against it. This needs a deliberate bump periodically; if that maintenance is unwelcome, reverting to `@latest` is a defensible call for an explicitly user-invoked scaffolding command.

## Credential-at-rest hygiene (low)

- `~/.elevenlabs` is created `0700`, and its config is written through the `O_NOFOLLOW` + `0600` primitive rather than a raw `fs::write`.
- `init` writes a `.gitignore` covering `.env`, with `.env.example` as the tracked template. It deliberately does **not** ignore the config directories: committing those is the point of managing agents as code, and ignoring them fails silently — `agents.json` would be tracked while the configs it references were not, so the project looks fine locally and breaks on a fresh clone. A test asserts this.
- `init`'s next-steps pointed at `elevenlabs auth login`, which does not exist in v1. It now shows the environment variable that actually works.

## Lockfile and CI

`Cargo.lock` was unresolvable — the generated crates had started using `chrono` but the lockfile committed by the regeneration did not contain it. This silently disabled `cargo audit` and `--locked` instead of failing anything. Regenerated: 331 crates, 0 advisories.

A new `audit` CI job verifies the lockfile still resolves and runs `cargo audit`, so the next regeneration that ships an incomplete lock fails on its own PR. Verified that the check does fail against the previously committed lock, so it is not decorative. Audit fails on advisories only; unmaintained/yanked warnings are non-blocking because the dependency graph is generator-controlled and an unfixable warning would otherwise block every unrelated PR.

## Not addressed here

Four findings are in generated code or the vendored framework and need to go upstream to Fern rather than being patched here, since regeneration would revert them: cross-host redirects resending the API key, `.env`-driven base-URL/TLS/proxy overrides, `--dry-run`/`--debug` printing the key, and a latent server-controlled pagination URL.

## Testing

Full suite green: 1752 framework + 61 workflow + 2 + 345 wire + doc tests. The workflow suite includes 7 containment regressions, 6 covering pagination termination, and one pinning the `.gitignore` contents. All new code is under paths already protected by `.fernignore`, so it survives regeneration.

Not verified end-to-end: `components add` against the live registry, which rate-limits automated requests (HTTP 429 from its bot check). The pinned version resolves and reaches the registry; the final add is untested.