### PR TITLE
fix(auth): explain missing API key permissions

### DIFF
--- a/src/auth/__tests__/api-key-validation.test.ts
+++ b/src/auth/__tests__/api-key-validation.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "@jest/globals";
+import { formatApiKeyValidationError } from "../api-key-validation";
+
+describe("formatApiKeyValidationError", () => {
+  it("explains the required scope for a permission-restricted key", () => {
+    const error = {
+      statusCode: 401,
+      body: {
+        detail: {
+          code: "unauthorized",
+          status: "missing_permissions",
+        },
+      },
+    };
+
+    expect(formatApiKeyValidationError(error)).toBe(
+      'API key is missing the required "Conversational AI: Read" permission ' +
+        "(convai_read). Enable it at https://elevenlabs.io/app/settings/api-keys."
+    );
+  });
+
+  it("supports missing_permissions in the current detail code field", () => {
+    const error = {
+      statusCode: 401,
+      body: { detail: { code: "missing_permissions" } },
+    };
+
+    expect(formatApiKeyValidationError(error)).toContain("convai_read");
+  });
+
+  it("distinguishes an invalid or expired key", () => {
+    expect(formatApiKeyValidationError({ statusCode: 401 })).toBe(
+      "Invalid or expired API key. Create or edit a key at " +
+        "https://elevenlabs.io/app/settings/api-keys."
+    );
+  });
+
+  it("suggests checking both scope and IP restrictions for other access denials", () => {
+    expect(formatApiKeyValidationError({ statusCode: 403 })).toBe(
+      "API key access was denied. Check its Conversational AI read permission " +
+        "and IP restrictions at https://elevenlabs.io/app/settings/api-keys."
+    );
+  });
+
+  it("keeps network failures separate from credential failures", () => {
+    expect(formatApiKeyValidationError({ code: "ENOTFOUND" })).toBe(
+      "Network error: Unable to connect to ElevenLabs API"
+    );
+  });
+
+  it("preserves unexpected SDK error messages", () => {
+    expect(
+      formatApiKeyValidationError(new Error("Unexpected response shape"))
+    ).toBe("Error verifying API key: Unexpected response shape");
+  });
+});

--- a/src/auth/api-key-validation.ts
+++ b/src/auth/api-key-validation.ts
@@ -1,0 +1,66 @@
+const API_KEY_SETTINGS_URL = "https://elevenlabs.io/app/settings/api-keys";
+
+type ErrorRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): ErrorRecord | undefined {
+  return typeof value === "object" && value !== null
+    ? (value as ErrorRecord)
+    : undefined;
+}
+
+function getDetail(error: ErrorRecord | undefined): ErrorRecord | undefined {
+  const body = asRecord(error?.body);
+  return asRecord(body?.detail);
+}
+
+function getString(
+  record: ErrorRecord | undefined,
+  key: string
+): string | undefined {
+  const value = record?.[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+export function formatApiKeyValidationError(error: unknown): string {
+  const err = asRecord(error);
+  const detail = getDetail(err);
+  const detailCode = getString(detail, "code");
+  const legacyDetailStatus = getString(detail, "status");
+  const message = getString(err, "message");
+  const code = getString(err, "code");
+  const statusCode =
+    typeof err?.statusCode === "number" ? err.statusCode : undefined;
+
+  // ElevenLabs currently returns missing endpoint permissions as HTTP 401,
+  // so this check must precede the generic invalid-key branch.
+  if (
+    detailCode === "missing_permissions" ||
+    legacyDetailStatus === "missing_permissions"
+  ) {
+    return (
+      'API key is missing the required "Conversational AI: Read" permission ' +
+      `(convai_read). Enable it at ${API_KEY_SETTINGS_URL}.`
+    );
+  }
+
+  if (statusCode === 401 || message?.includes("401")) {
+    return `Invalid or expired API key. Create or edit a key at ${API_KEY_SETTINGS_URL}.`;
+  }
+
+  if (statusCode === 403 || message?.includes("403")) {
+    return (
+      "API key access was denied. Check its Conversational AI read permission " +
+      `and IP restrictions at ${API_KEY_SETTINGS_URL}.`
+    );
+  }
+
+  if (
+    code === "ENOTFOUND" ||
+    code === "ETIMEDOUT" ||
+    message?.toLowerCase().includes("network")
+  ) {
+    return "Network error: Unable to connect to ElevenLabs API";
+  }
+
+  return `Error verifying API key: ${message ?? String(error)}`;
+}

--- a/src/auth/commands/login.ts
+++ b/src/auth/commands/login.ts
@@ -6,6 +6,7 @@ import { setApiKey, loadConfig } from '../../shared/config.js';
 import { getApiBaseUrl } from '../../shared/elevenlabs-api.js';
 import { listAgentsApi } from '../../shared/elevenlabs-api.js';
 import { ElevenLabsClient } from '@elevenlabs/elevenlabs-js';
+import { formatApiKeyValidationError } from '../api-key-validation.js';
 
 export function createLoginCommand(): Command {
   return new Command('login')
@@ -52,14 +53,7 @@ export function createLoginCommand(): Command {
             await listAgentsApi(testClient, 1);
             console.log('API key verified successfully');
           } catch (error: unknown) {
-            const err = error as { statusCode?: number; message?: string; code?: string };
-            if (err?.statusCode === 401 || err?.message?.includes('401')) {
-              console.error('Invalid API key');
-            } else if (err?.code === 'ENOTFOUND' || err?.code === 'ETIMEDOUT' || err?.message?.includes('network')) {
-              console.error('Network error: Unable to connect to ElevenLabs API');
-            } else {
-              console.error('Error verifying API key:', err?.message || error);
-            }
+            console.error(formatApiKeyValidationError(error));
             process.exit(1);
           }
 


### PR DESCRIPTION
Fixes #80

## Summary

- inspect the ElevenLabs error body before classifying HTTP 401 responses as invalid keys
- explain that `missing_permissions` requires the Conversational AI read (`convai_read`) permission and link directly to API-key settings
- keep invalid/expired keys, other access denials (including IP restrictions), network failures, and unexpected errors distinct

## Test plan

- `jest --testPathIgnorePatterns='e2e' --runInBand` — 20 suites, 249 tests passed
- `tsc --noEmit`
- `eslint src -c eslint.config.js` — 0 errors (11 pre-existing warnings in unrelated tests)
