### PR TITLE
docs: add Homebrew and Scoop install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,29 @@ The CLI does two things:
 
 ## Installation
 
+### Homebrew (macOS / Linux)
+
+```bash
+brew install elevenlabs/tap/elevenlabs
+```
+
+### Scoop (Windows)
+
+```powershell
+scoop bucket add elevenlabs https://github.com/elevenlabs/scoop-bucket
+scoop install elevenlabs
+```
+
 ### Shell (macOS / Linux)
 
 ```bash
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/elevenlabs/cli/releases/latest/download/elevenlabs-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/elevenlabs/cli/releases/latest/download/elevenlabs-cli-installer.sh | sh
 ```
 
 ### PowerShell (Windows)
 
 ```powershell
-powershell -ExecutionPolicy ByPass -c "irm https://github.com/elevenlabs/cli/releases/latest/download/elevenlabs-installer.ps1 | iex"
+powershell -ExecutionPolicy ByPass -c "irm https://github.com/elevenlabs/cli/releases/latest/download/elevenlabs-cli-installer.ps1 | iex"
 ```
 
 ### Build from source


### PR DESCRIPTION
Homebrew and Scoop are the primary distribution channels, but the README only documented the shell and PowerShell installers. Adds both, listed first since they are what most users should reach for.

```bash
brew install elevenlabs/tap/elevenlabs           # macOS / Linux

scoop bucket add elevenlabs https://github.com/elevenlabs/scoop-bucket
scoop install elevenlabs                          # Windows
```

## Also fixes two broken URLs

The existing shell and PowerShell commands pointed at `elevenlabs-installer.sh` / `.ps1`, but the release assets are `elevenlabs-cli-installer.{sh,ps1}` — the package is `elevenlabs-cli` and cargo-dist names artifacts after it. Both commands 404 as written.

Verified against v1.0.0-alpha.3's published assets and `dist plan --tag=v1.0.0`; the tap and bucket paths the new instructions rely on both exist (`Formula/elevenlabs.rb`, `bucket/elevenlabs.json`).

## Note

`releases/latest` only resolves to non-prerelease releases, so the curl and irm commands stay 404 until v1.0.0 is tagged as a stable release — every release so far is a prerelease, and `latest` currently points at `@elevenlabs/cli@0.5.6` (v0). The Homebrew and Scoop instructions work today. Nothing to change here; the tag fixes it.

`README.md` is in `.fernignore`, so this survives regeneration.