### PR TITLE
feat: tag CLI requests with the command that made them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,7 +472,7 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "elevenlabs-cli"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elevenlabs-cli"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 description = "CLI for the ElevenLabs API"
 license = "MIT"

--- a/cli/elevenlabs/workflow/agents.rs
+++ b/cli/elevenlabs/workflow/agents.rs
@@ -116,6 +116,7 @@ const GITIGNORE_BODY: &str =
     "# Credentials — never commit these. Use .env.example as the tracked template.\n.env\n";
 
 fn handle_init(args: InitArgs, _ctx: &AppContext) -> Result<(), CliError> {
+    let _scope = api::command_scope("agents.init");
     let root = PathBuf::from(&args.path);
     let abs = std::env::current_dir()
         .map(|cwd| cwd.join(&root))
@@ -275,6 +276,7 @@ struct AddArgs {
 }
 
 fn handle_add(args: AddArgs, ctx: &AppContext) -> Result<(), CliError> {
+    let _scope = api::command_scope("agents.add");
     if args.from_file.is_some() && args.template.is_some() {
         return Err(CliError::Validation(
             "Cannot use both --from-file and --template options together".to_string(),
@@ -363,6 +365,7 @@ fn handle_add(args: AddArgs, ctx: &AppContext) -> Result<(), CliError> {
 struct NoArgs {}
 
 fn handle_status(_args: NoArgs, _ctx: &AppContext) -> Result<(), CliError> {
+    let _scope = api::command_scope("agents.status");
     let config = require_agents()?;
     if config.agents.is_empty() {
         println!("No agents configured");
@@ -406,6 +409,7 @@ struct WidgetArgs {
 }
 
 fn handle_widget(args: WidgetArgs, _ctx: &AppContext) -> Result<(), CliError> {
+    let _scope = api::command_scope("agents.widget");
     let config = require_agents()?;
     let agent = config
         .agents
@@ -447,6 +451,7 @@ struct TestArgs {
 }
 
 fn handle_test(args: TestArgs, ctx: &AppContext) -> Result<(), CliError> {
+    let _scope = api::command_scope("agents.test");
     let config = require_agents()?;
     // ID first so existing scripts keep resolving identically, then fall back
     // to the display name in the config file. `init`'s next-steps tell users
@@ -606,6 +611,7 @@ fn push_command() -> clap::Command {
 }
 
 fn handle_push(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliError> {
+    let _scope = api::command_scope("agents.push");
     let agent = opt_string(matches, "agent");
     let branch = opt_string(matches, "branch");
     let version_description = opt_string(matches, "version-description");
@@ -835,6 +841,7 @@ fn pull_command() -> clap::Command {
 }
 
 fn handle_pull(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliError> {
+    let _scope = api::command_scope("agents.pull");
     let agent = opt_string(matches, "agent");
     let branch = opt_string(matches, "branch");
     let all_branches = matches.get_flag("all-branches");

--- a/cli/elevenlabs/workflow/api.rs
+++ b/cli/elevenlabs/workflow/api.rs
@@ -43,6 +43,64 @@ fn advance_cursor(resp: &Value, seen: &mut std::collections::HashSet<String>) ->
     Some(next.to_string())
 }
 
+/// Tag the outgoing `User-Agent` with the command that is running, for the
+/// lifetime of one CLI invocation.
+///
+/// Why the User-Agent and not a header: `RequestOptions.additional_headers`
+/// never reaches the wire. `HttpClient::send_request` only calls
+/// `apply_custom_headers` on its non-executor branch, and this CLI always uses
+/// the executor — which is also why the `X-Source` below is silently dropped.
+/// The `User-Agent` is the one identifier that does arrive, and `HttpConfig`
+/// reads its suffix env var at client-build time, so setting it here is picked
+/// up by every request the command makes.
+///
+/// The tag is **always a static string** chosen by the caller. It must never be
+/// derived from argv: positional tokens carry user data (`agents test my-agent`
+/// would put the agent's name in the User-Agent and from there into request
+/// logs).
+///
+/// Appends rather than replaces, so a consumer's own `ELEVENLABS_VIA` survives.
+/// Restores the previous value on drop, so one command cannot leak its tag into
+/// another (`agents push` shells out to nothing today, but `--dry-run` paths and
+/// tests share a process).
+pub struct CommandScope {
+    key: String,
+    previous: Option<String>,
+}
+
+/// Env var the framework reads for the User-Agent suffix. The segment tracks
+/// the configured flag name (`userAgentSuffixFlag: via` → `_VIA`), so a rename
+/// upstream does not silently detach this.
+fn suffix_env_key() -> String {
+    format!(
+        "ELEVENLABS{}",
+        fern_cli_sdk::user_agent::suffix_env_segment()
+    )
+}
+
+pub fn command_scope(command: &'static str) -> CommandScope {
+    let key = suffix_env_key();
+    let previous = std::env::var(&key).ok();
+    let tag = format!("cmd/{command}");
+    let combined = match previous.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        Some(existing) => format!("{existing} {tag}"),
+        None => tag,
+    };
+    // Single-threaded: one command is dispatched per process, and the request
+    // futures run on a current-thread runtime via `sdk::block_on`.
+    std::env::set_var(&key, combined);
+    CommandScope { key, previous }
+}
+
+impl Drop for CommandScope {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(v) => std::env::set_var(&self.key, v),
+            None => std::env::remove_var(&self.key),
+        }
+    }
+}
+
 /// `X-Source` tag v0 attached to every request.
 const X_SOURCE: &str = "agents-cli";
 
@@ -514,6 +572,73 @@ pub fn get_test_invocation(ctx: &AppContext, invocation_id: &str) -> Result<Valu
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // `command_scope` mutates process-wide env, so these must not interleave.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn with_env<T>(body: impl FnOnce(&str) -> T) -> T {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let key = suffix_env_key();
+        let saved = std::env::var(&key).ok();
+        std::env::remove_var(&key);
+        let out = body(&key);
+        match saved {
+            Some(v) => std::env::set_var(&key, v),
+            None => std::env::remove_var(&key),
+        }
+        out
+    }
+
+    #[test]
+    fn scope_tags_the_user_agent_suffix_and_restores_on_drop() {
+        with_env(|key| {
+            {
+                let _scope = command_scope("agents.push");
+                assert_eq!(std::env::var(key).as_deref(), Ok("cmd/agents.push"));
+            }
+            // Restored to absent, so one command cannot leak its tag into the next.
+            assert!(std::env::var(key).is_err());
+        });
+    }
+
+    #[test]
+    fn scope_appends_rather_than_clobbering_a_consumer_token() {
+        with_env(|key| {
+            std::env::set_var(key, "partner-app/3.1");
+            {
+                let _scope = command_scope("tools.pull");
+                assert_eq!(
+                    std::env::var(key).as_deref(),
+                    Ok("partner-app/3.1 cmd/tools.pull")
+                );
+            }
+            assert_eq!(std::env::var(key).as_deref(), Ok("partner-app/3.1"));
+        });
+    }
+
+    #[test]
+    fn scope_ignores_a_blank_existing_value() {
+        with_env(|key| {
+            std::env::set_var(key, "   ");
+            let _scope = command_scope("tests.add");
+            assert_eq!(std::env::var(key).as_deref(), Ok("cmd/tests.add"));
+        });
+    }
+
+    #[test]
+    fn suffix_env_key_tracks_the_configured_flag_name() {
+        // Guards against the flag being renamed upstream (userAgentSuffixFlag)
+        // without this following it — the tag would silently stop being read.
+        let key = suffix_env_key();
+        assert!(key.starts_with("ELEVENLABS"), "unexpected key: {key}");
+        assert_eq!(
+            key,
+            format!(
+                "ELEVENLABS{}",
+                fern_cli_sdk::user_agent::suffix_env_segment()
+            )
+        );
+    }
 
     #[test]
     fn api_error_message_handles_every_shape_the_api_returns() {

--- a/cli/elevenlabs/workflow/tests.rs
+++ b/cli/elevenlabs/workflow/tests.rs
@@ -277,6 +277,7 @@ struct AddArgs {
 }
 
 fn handle_add(args: AddArgs, ctx: &AppContext) -> Result<(), CliError> {
+    let _scope = api::command_scope("tests.add");
     let config = test_template_by_name(&args.name, &args.template)?;
 
     let mut registry = if Path::new(project::TESTS_FILE).exists() {
@@ -337,6 +338,7 @@ struct DeleteArgs {
 }
 
 fn handle_delete(args: DeleteArgs, ctx: &AppContext) -> Result<(), CliError> {
+    let _scope = api::command_scope("tests.delete");
     let mut registry = require_tests()?;
 
     if args.all {
@@ -443,6 +445,7 @@ fn push_command() -> clap::Command {
 }
 
 fn handle_push(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliError> {
+    let _scope = api::command_scope("tests.push");
     let test_filter = opt_string(matches, "test");
     let config_dir =
         opt_string(matches, "config-dir").unwrap_or_else(|| "test_configs".to_string());
@@ -588,6 +591,7 @@ fn pull_command() -> clap::Command {
 }
 
 fn handle_pull(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliError> {
+    let _scope = api::command_scope("tests.pull");
     let test_filter = opt_string(matches, "test");
     let output_dir =
         opt_string(matches, "output-dir").unwrap_or_else(|| "test_configs".to_string());

--- a/cli/elevenlabs/workflow/tools.rs
+++ b/cli/elevenlabs/workflow/tools.rs
@@ -117,6 +117,7 @@ struct AddArgs {
 }
 
 fn handle_add(args: AddArgs, ctx: &AppContext) -> Result<(), CliError> {
+    let _scope = api::command_scope("tools.add");
     let config = match args.tool_type.as_str() {
         "webhook" => default_webhook_tool(&args.name),
         "client" => default_client_tool(&args.name),
@@ -189,6 +190,7 @@ struct DeleteArgs {
 }
 
 fn handle_delete(args: DeleteArgs, ctx: &AppContext) -> Result<(), CliError> {
+    let _scope = api::command_scope("tools.delete");
     let mut registry = require_tools()?;
 
     if args.all {
@@ -302,6 +304,7 @@ fn push_command() -> clap::Command {
 }
 
 fn handle_push(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliError> {
+    let _scope = api::command_scope("tools.push");
     let tool_filter = opt_string(matches, "tool");
     let dry_run = dry_run_flag(matches);
 
@@ -428,6 +431,7 @@ fn pull_command() -> clap::Command {
 }
 
 fn handle_pull(matches: &clap::ArgMatches, ctx: &AppContext) -> Result<(), CliError> {
+    let _scope = api::command_scope("tools.pull");
     let tool_filter = opt_string(matches, "tool");
     let output_dir =
         opt_string(matches, "output-dir").unwrap_or_else(|| "tool_configs".to_string());


### PR DESCRIPTION
Nothing on the backend can currently tell that a request came from the CLI, let alone which product it belongs to. `request_log.py` identifies clients by `X-Fern-SDK-Name`; the CLI's entire header set is `accept, accept-encoding, authorization, host, user-agent`.

`path_pattern` is already logged, so once CLI traffic is identifiable most products fall out of the path. The one thing paths cannot express is **agents-as-code**: `agents push` and `agents create` hit the same convai endpoints. This adds that missing dimension.

Each workflow handler opens a `CommandScope`, which appends `cmd/<command>` to the User-Agent for the duration of the command:

```
User-Agent: elevenlabs-cli/1.0.0 cmd/agents.push
```

Pairs with the backend change in `xi` (`feat/log-cli-traffic`), which parses this into `client_kind`, `sdk_name`, `sdk_version` and `cli_command`.

## Why the User-Agent and not a header

`RequestOptions.additional_headers` never reaches the wire. `HttpClient::send_request` only calls `apply_custom_headers` on its **non-executor** branch, and this CLI always uses the executor:

```rust
if let Some(executor) = &self.executor {
    executor.execute(req).await          // no apply_custom_headers
} else {
    self.apply_custom_headers(&mut req, options)?;
    ...
}
```

That is also why the `X-Source: agents-cli` we already set is silently dropped — and why v0's attribution via `is_agents_cli_x_source` (`xi_shared_workspace/generation_attribution.py:144`, `constants.py:43`) stopped firing on v1. Worth reporting upstream alongside the `parse_response` status-check fix they shipped in 0.38.0, since it is the same structural gap.

## Tags are static, never derived from argv

`crate::cli_args::extract_subcommand_path` is public and would have been convenient, but it returns *positional tokens* — `agents test my-agent` would put the agent's name in the User-Agent and from there into request logs. Every tag here is a static string chosen per handler, and the `&'static str` signature enforces it.

## Verified on the wire

```
agents pull                       ->  elevenlabs-cli/1.0.0 cmd/agents.pull
tools pull                        ->  elevenlabs-cli/1.0.0 cmd/tools.pull
models list (generated)           ->  elevenlabs-cli/1.0.0
ELEVENLABS_VIA=envtoken/2.0 ...   ->  elevenlabs-cli/1.0.0 envtoken/2.0 cmd/agents.pull
--via partner/9.9                 ->  elevenlabs-cli/1.0.0 partner/9.9
```

Plus a leak check: `agents test "my secret agent name"` puts nothing user-supplied in any User-Agent.

**The last row is a deliberate gap.** `--via` sets an override that beats the env var wholesale, so an explicit `--via` drops our tag. Losing telemetry is the right side to fail on versus clobbering a consumer's own token — but it means `--via` users are invisible in the command dimension. Closing that needs framework support for composing the two.

## Scope

Covers the 15 hand-written workflow handlers, which is exactly the set `path_pattern` cannot distinguish. Generated commands (TTS, dubbing, …) are already product-identifiable from the path. Command-level data for those needs Fern to emit it at dispatch, where `op_path` is known.

## Tests

4 new unit tests covering the tag format, append-not-clobber, restore-on-drop, and that the env key tracks the configured flag name (so a `userAgentSuffixFlag` rename upstream cannot silently detach this). Full suite green: 1903 + 68 + 2 + 755 + doc.

All changes are under `cli/elevenlabs/workflow/`, which is fernignored.