### PR TITLE
Ship README and LICENSE in the npm packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,6 +324,26 @@ jobs:
           fi
           install -m 0755 "${BIN}" "${PKG_DIR}/${BINARY_NAME}"
 
+          # npm always ships README and LICENSE regardless of `files`, so
+          # placing them is enough. Without them the package page renders
+          # empty and npm reports the package as unlicensed.
+          LICENSE_SRC=$(find extract -type f -name LICENSE -print -quit)
+          if [[ -n "${LICENSE_SRC}" ]]; then
+            install -m 0644 "${LICENSE_SRC}" "${PKG_DIR}/LICENSE"
+          fi
+
+          # Deliberately not the repository README: this package is not one
+          # users install directly, so it gets a note saying so.
+          cat > "${PKG_DIR}/README.md" <<README
+          # ${PLATFORM_PKG}
+
+          Platform-specific binary for [\`@elevenlabs/cli\`](https://www.npmjs.com/package/@elevenlabs/cli)
+          on ${SUFFIX}.
+
+          Do not install this directly — install \`@elevenlabs/cli\`, which selects
+          the right platform package for you.
+          README
+
           cat > "${PKG_DIR}/package.json" <<PKGJSON
           {
             "name": "${PLATFORM_PKG}",
@@ -416,6 +436,11 @@ jobs:
             "files": ["bin/"]
           }
           PKGJSON
+
+          # The page users actually land on, so it gets the repository README
+          # from the tagged commit. npm ships both regardless of `files`.
+          cp README.md "${PKG_DIR}/README.md"
+          cp LICENSE "${PKG_DIR}/LICENSE"
 
           # Write launcher script
           mkdir -p "${PKG_DIR}/bin"


### PR DESCRIPTION
The 1.1.0 launcher tarball published yesterday contains exactly two files:

```
package/bin/cli.js
package/package.json
```

No README, so [npmjs.com/package/@elevenlabs/cli](https://www.npmjs.com/package/@elevenlabs/cli) renders a blank page, and no LICENSE, so npm reports all six packages as unlicensed. The `files` array is `["bin/"]`, and the platform packages have the same gap.

This carried over from the generated workflow — worth reporting upstream, since any CLI built with the Fern generator will publish blank npm pages.

## Changes

**Launcher** — copies the repository `README.md` and `LICENSE` from the tagged checkout, so the page users land on shows the CLI documentation.

**Platform packages** — take `LICENSE` from the archive the job already downloads and attestation-verifies, located with the same `find -type f -name` lookup used for the binary rather than an assumed path, and skipped if absent. They get a short generated README saying not to install them directly; the full CLI README would be misleading on a package nobody should install by hand.

No `files` change: npm always ships README and LICENSE regardless of that array. Verified by packing a fixture with `files: ["bin/"]` — both were included, an unrelated file was not.

## Testing

Simulated both steps against the real v1.1.0 release archives.

Platform package, from the `.tar.gz`:

```
1.1kB   LICENSE       (from the archive)
250B    README.md     (generated)
18.5MB  elevenlabs
80B     package.json
```

The `.zip` layout was checked separately, since it holds its files at the archive root rather than inside `elevenlabs-cli-<target>/` — `find` locates both `LICENSE` and `elevenlabs.exe` correctly there.

Launcher:

```
1.1kB   LICENSE
13.4kB  README.md
15B     bin/cli.js
98B     package.json
```

The generated README renders correctly, with the escaped backticks and link surviving the heredoc.

## Not fixed here

1.1.0 cannot be repaired — npm versions are immutable and the README lives in the tarball. The page stays blank until 1.2.0, which is the deliberate choice: publishing an npm-only 1.1.1 would put npm a patch ahead of Homebrew and Scoop again.