### PR TITLE
Add npm to the README install options

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ scoop bucket add elevenlabs https://github.com/elevenlabs/scoop-bucket
 scoop install elevenlabs
 ```
 
+### npm (macOS / Linux / Windows)
+
+```bash
+npm install -g @elevenlabs/cli
+```
+
+Installs the same binary through a thin launcher, picking the right build for
+your platform. Use `npx @elevenlabs/cli <command>` to run it once without
+installing it globally.
+
 ### Shell (macOS / Linux)
 
 ```bash


### PR DESCRIPTION
npm distribution is live — all six packages publish at `1.1.0` — so the README should list it alongside Homebrew, Scoop and the shell installers.

```markdown
### npm (macOS / Linux / Windows)

npm install -g @elevenlabs/cli

Installs the same binary through a thin launcher, picking the right build for
your platform. Use `npx @elevenlabs/cli <command>` to run it once without
installing it globally.
```

Placed after Scoop so the three package managers sit together and the raw installers stay below them, matching the ordering in the docs snippet (elevenlabs-dx#2651).

## Why the wording

"the same binary" is now literally true rather than a nicety: since #134 the npm packages repackage the archives cargo-dist built for the tag, verified with `gh attestation verify`, instead of compiling their own. Before that they were a separate build that selected a different TLS backend on macOS and Windows.

## Verified

```
$ npm install @elevenlabs/cli   ->  added 2 packages
$ elevenlabs --version          ->  elevenlabs 1.1.0
$ npx @elevenlabs/cli@1.1.0 models list --dry-run   ->  works
```

The `npx` line is checked with a real subcommand, not just `--version`.

## Note

This README ships inside the `@elevenlabs/cli` npm package as of #135, so it is also what npmjs.com will render for the package from 1.2.0 onward. The 1.1.0 page stays blank until then — that tarball predates the fix and npm versions are immutable.

The table of contents lists only `##` headings, so it needs no change.